### PR TITLE
Gesture tips in settings

### DIFF
--- a/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
@@ -302,6 +302,15 @@ public class LiveWallpaperSettings extends AppCompatActivity {
                 });
             }
 
+            // ─── pref_gesture_tips → informational dialog ─────────────────
+            Preference gestureTips = findPreference("pref_gesture_tips");
+            if (gestureTips != null) {
+                gestureTips.setOnPreferenceClickListener(pref -> {
+                    showGestureTipsDialog();
+                    return true;
+                });
+            }
+
         }
 
         @Override
@@ -449,6 +458,33 @@ public class LiveWallpaperSettings extends AppCompatActivity {
                         Toast.LENGTH_LONG
                 ).show();
             }
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        //  Gesture tips dialog
+        // ─────────────────────────────────────────────────────────────────
+
+        /**
+         * Shows a read-only informational dialog explaining how to spin the
+         * sphere without triggering launcher gestures.
+         *
+         * <p>Key points covered:
+         * <ul>
+         *   <li>Two-finger drag is the conflict-free rotation gesture.</li>
+         *   <li>One-finger drag is shared with the launcher by Android design —
+         *       no app can change that.</li>
+         *   <li>Last-home-page trick to reduce page-switch conflicts.</li>
+         *   <li>One UI setting and Good Lock tip to suppress the notification
+         *       panel pull-down.</li>
+         * </ul>
+         * </p>
+         */
+        private void showGestureTipsDialog() {
+            new MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.dialog_gesture_tips_title)
+                    .setMessage(R.string.dialog_gesture_tips_message)
+                    .setPositiveButton(R.string.dialog_gesture_tips_ok, null)
+                    .show();
         }
 
         /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="pref_icon_size_summary">Adjust the size of app icons on the sphere</string>
     <string name="pref_rotation_speed_title">Rotation speed</string>
     <string name="pref_rotation_speed_summary">Idle spin and fling momentum multiplier (100 = 1×)</string>
+    <string name="pref_gesture_tips_title">Gesture tips</string>
+    <string name="pref_gesture_tips_summary">Spin the sphere without fighting the launcher</string>
 
     <!-- Performance -->
     <string name="pref_category_performance">Performance</string>
@@ -49,6 +51,9 @@
     <string name="stepper_increment">Increase page number</string>
 
     <!-- Dialogs -->
+    <string name="dialog_gesture_tips_title">Spinning the sphere</string>
+    <string name="dialog_gesture_tips_message">Two-finger drag — use two fingers to spin the sphere. The launcher ignores multi-finger touches, so this is the conflict-free way to rotate.\n\nOne-finger drag — Android gives the launcher first claim on single-finger swipes, so the launcher always reacts too (page switching, app drawer, notification panel). No app can override this.\n\nLast home page trick — place the sphere on your last home screen page. Swiping right-to-left there has no further page to switch to, so the sphere gets the gesture.\n\nOne UI tip — go to Home screen settings and turn off \"Swipe down for notification panel\" to stop the panel appearing while you spin. For deeper control, Good Lock → Home Up lets you remap home screen gestures.</string>
+    <string name="dialog_gesture_tips_ok">Got it</string>
     <string name="dialog_group_name_hint">Group name (e.g., Social)</string>
     <string name="dialog_delete_confirm">Delete group &#8220;%1$s&#8221;?</string>
     <string name="dialog_delete_confirm_msg">The apps in this group will become ungrouped.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -48,6 +48,10 @@
             android:summary="@string/pref_rotation_speed_summary"
             android:defaultValue="100" android:max="300"
             app:min="10" app:showSeekBarValue="true" />
+        <Preference
+            android:key="pref_gesture_tips"
+            android:title="@string/pref_gesture_tips_title"
+            android:summary="@string/pref_gesture_tips_summary" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_category_performance">


### PR DESCRIPTION
## Summary

- Adds a **Gesture tips** preference row at the bottom of the Sphere category in Settings
- Tapping it opens a `MaterialAlertDialogBuilder` dialog (title: "Spinning the sphere") that explains:
  - Two-finger drag is the conflict-free spin — the launcher ignores multi-finger touches
  - One-finger drag is shared with the launcher by Android design; no app can change that
  - Last-home-page trick: the sphere on the final page can't trigger page switching rightward
  - One UI tip: turn off "Swipe down for notification panel" in Home screen settings; Good Lock → Home Up for deeper control
- All copy is in string resources following existing naming conventions (`pref_gesture_tips_*`, `dialog_gesture_tips_*`)

Fixes #4

## Test plan

- [ ] Open AuraOrbit Settings → Sphere category → "Gesture tips" row appears last
- [ ] Tap it → dialog titled "Spinning the sphere" appears with all four points and a "Got it" button
- [ ] "Got it" dismisses the dialog
- [ ] No layout regressions in other Sphere rows (Sphere Size, Icon Size, Rotation speed)
- [ ] Build clean: `./gradlew :app:processDebugResources :app:compileDebugJavaWithJavac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)