### PR TITLE
Launcher-state accessibility service: exact page + drawer detection (One UI)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,37 @@
             </intent-filter>
         </activity>
 
+        <!-- ═══════════════════════════════════════════════════════════════
+             3. LAUNCHER STATE ACCESSIBILITY SERVICE (opt-in)
+
+             Fixes #10 + #11: On One UI, live wallpapers receive no page-offset
+             or drawer-state callbacks. This accessibility service reads the
+             Samsung launcher's page indicator so the sphere knows the exact
+             home page and whether the app drawer is open, suppressing spurious
+             app launches through the drawer.
+
+             Scope: com.sec.android.app.launcher only (declared in
+             res/xml/launcher_state_service.xml). Reads only page indicator
+             contentDescriptions — no user data is accessed.
+
+             The service is opt-in: it does nothing until the user enables it
+             from Settings → Accessibility → AuraOrbit.
+             ═══════════════════════════════════════════════════════════════ -->
+        <service
+            android:name=".LauncherStateService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/launcher_state_service" />
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/dev/jaimin/auraorbit/LauncherStateService.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/LauncherStateService.java
@@ -24,10 +24,11 @@ import java.util.regex.Pattern;
  *      launch apps.
  *
  * #11: One UI never sends page-offset events to live wallpapers.  This service
- *      reads the launcher's page indicator (content-desc "Page N of M. ") and
- *      publishes the exact 0-based page into {@link LauncherState#page}.
- *      SphereEngine uses this as the highest-priority page source, replacing the
- *      dead-reckoning swipe counter that can drift.
+ *      reads the launcher's page indicator (content-desc "Page N of M. " or
+ *      "Home screen N of M") and publishes the 1-based page into
+ *      {@link LauncherState#page} (0 = no data yet).  SphereEngine uses this as
+ *      the highest-priority page source, replacing the dead-reckoning swipe
+ *      counter that can drift.
  *
  * ─── Scope and privacy ────────────────────────────────────────────────────────
  *
@@ -66,14 +67,20 @@ public class LauncherStateService extends AccessibilityService {
     private static final String TAG = "AuraOrbit.A11y";
 
     /**
-     * Pattern matching One UI page-indicator content descriptions.
+     * Pattern matching One UI home-screen page-indicator content descriptions.
      *
-     * Observed format:  "Page 1 of 4. "  (note trailing ". ")
+     * Observed formats (Samsung wording varies slightly by One UI version):
+     *   Standard:     "Page 1 of 4. "       (note trailing ". ")
+     *   Alternate:    "Home screen 1 of 4"  (older/regional Samsung builds)
+     *
      * The pattern is tolerant of any whitespace between words and of the
-     * trailing dot-space, matching both "Page 1 of 4." and "Page 1 of 4. ".
+     * trailing dot-space, matching both "Page 1 of 4." and "Page 1 of 4. "
+     * as well as "Home screen 1 of 4" (with or without trailing punctuation).
      */
     private static final Pattern PAGE_PATTERN =
-            Pattern.compile("(?i)page\\s+(\\d+)\\s+of\\s+(\\d+)");
+            Pattern.compile(
+                    "(?i)(?:page\\s+(\\d+)\\s+of\\s+(\\d+)"
+                    + "|home\\s*screen\\s+(\\d+)\\s+of\\s+(\\d+))");
 
     /**
      * Minimum nanoseconds between full node-tree scans.
@@ -90,6 +97,10 @@ public class LauncherStateService extends AccessibilityService {
     private int eventCountSinceLog = 0;
     /** Emit a log line every N events to confirm the service is alive. */
     private static final int LOG_EVERY_N = 50;
+    /** Nanosecond timestamp of the last "home page parsed" log line. */
+    private long lastHomePageLogNanos = 0L;
+    /** Minimum interval between "home page" log lines (1 second). */
+    private static final long HOME_PAGE_LOG_THROTTLE_NS = 1_000_000_000L;
 
     // ═══════════════════════════════════════════════════════════════════════════
     //  Shared launcher state — visible process-wide via static fields
@@ -105,9 +116,17 @@ public class LauncherStateService extends AccessibilityService {
      */
     public static final class LauncherState {
         /**
-         * Current 0-based home-screen page (1-based from the indicator minus 1).
-         * Default 0 (first page). Only meaningful when {@link #serviceConnected} is
-         * true AND {@link #updatedNanos} is within the freshness window.
+         * Current 1-based home-screen page as parsed directly from the indicator
+         * (e.g. "Page 2 of 4" → page=2).  The default value 0 is the "no data yet"
+         * sentinel written at service start; it means the indicator has never been
+         * parsed (One UI hides the dots when at rest, only showing them mid-swipe).
+         *
+         * <p>SphereEngine treats page &lt; 1 as "no data" and falls through to the
+         * next page source (offsets or dead-reckoning) so the sphere does not
+         * collapse immediately after being applied before the first swipe.
+         *
+         * <p>Only meaningful when {@link #serviceConnected} is true AND
+         * {@link #updatedNanos} is within the freshness window.
          */
         public static volatile int page = 0;
 
@@ -219,8 +238,8 @@ public class LauncherStateService extends AccessibilityService {
      *   - drawerOpen = true when a drawer-classified indicator is present
      *     and visible, OR when the incoming event's class name hints at the
      *     apps-view container.
-     *   - page/pageCount come from the home-classified indicator (preferred)
-     *     or the drawer indicator if no home indicator was found.
+     *   - page/pageCount come from the home-classified indicator only (STICKY:
+     *     when no home indicator is found, the last known values are preserved).
      *
      * @param root  Root node of the active window (caller must recycle).
      * @param event The triggering event (used for class-name hint).
@@ -253,14 +272,29 @@ public class LauncherStateService extends AccessibilityService {
         // ─── Publish results ──────────────────────────────────────────────────
         boolean drawerOpen = foundDrawerIndicator || classHintDrawer;
 
-        int newPage      = (foundHomePage >= 0)  ? foundHomePage      : LauncherState.page;
-        int newPageCount = (foundHomeCount >= 0)  ? foundHomeCount     : LauncherState.pageCount;
-        // If no home indicator was found but a drawer indicator was, keep the
-        // last known home page (drawerOpen is true, sphere is suppressed anyway).
+        // STICKY page cache: the home page indicator only appears while the user
+        // is swiping (One UI fades out the dots when at rest).  When no indicator
+        // was found in this scan, keep the last known value — pages can only change
+        // via swipes, and swipes produce events when the indicator is visible.
+        // page=0 is the "no data yet" sentinel written at service start; it will
+        // be replaced the first time a swipe exposes the indicator.
+        // DRAWER indicators must NEVER write into the home page fields.
+        if (foundHomePage >= 0) {
+            // Successfully parsed a home page indicator — update the sticky cache.
+            LauncherState.page      = foundHomePage;
+            LauncherState.pageCount = foundHomeCount;
+            // Throttled log so activity is visible in logcat without spam.
+            long nowNs = System.nanoTime();
+            if (nowNs - lastHomePageLogNanos > HOME_PAGE_LOG_THROTTLE_NS) {
+                lastHomePageLogNanos = nowNs;
+                Log.d(TAG, "home page=" + foundHomePage + " of " + foundHomeCount);
+            }
+        }
+        // else: no home indicator in this scan — keep LauncherState.page/pageCount
+        // unchanged (sticky cache).  This covers both "at rest between swipes" and
+        // "drawer is open" — in neither case should we discard the last known page.
 
         LauncherState.drawerOpen   = drawerOpen;
-        LauncherState.page         = newPage;
-        LauncherState.pageCount    = newPageCount;
         LauncherState.updatedNanos = System.nanoTime();
     }
 
@@ -301,8 +335,12 @@ public class LauncherStateService extends AccessibilityService {
             Matcher m = PAGE_PATTERN.matcher(desc);
             if (m.find()) {
                 // This node is a page indicator. Parse page and count.
-                int indicatorPage  = parseIntSafe(m.group(1), 1);
-                int indicatorCount = parseIntSafe(m.group(2), 1);
+                // Pattern has two alternatives (groups 1+2 for "page N of M",
+                // groups 3+4 for "home screen N of M"): use whichever matched.
+                String pageGroup  = m.group(1) != null ? m.group(1) : m.group(3);
+                String countGroup = m.group(2) != null ? m.group(2) : m.group(4);
+                int indicatorPage  = parseIntSafe(pageGroup,  1);
+                int indicatorCount = parseIntSafe(countGroup, 1);
 
                 // Classify surface: is this a drawer indicator?
                 boolean isDrawerIndicator = isDrawerNode(node);
@@ -315,8 +353,10 @@ public class LauncherStateService extends AccessibilityService {
                 } else {
                     // Home-screen indicator: update page (only when visible).
                     if (node.isVisibleToUser() && result.homePage < 0) {
-                        // Convert 1-based indicator to 0-based internal page.
-                        result.homePage      = Math.max(0, indicatorPage - 1);
+                        // Store 1-based so LauncherState.page=0 unambiguously means
+                        // "no data yet" (the indicator has not been seen since start).
+                        // SphereEngine checks page >= 1 before trusting this value.
+                        result.homePage      = Math.max(1, indicatorPage);
                         result.homePageCount = indicatorCount;
                     }
                 }

--- a/app/src/main/java/dev/jaimin/auraorbit/LauncherStateService.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/LauncherStateService.java
@@ -1,0 +1,428 @@
+package dev.jaimin.auraorbit;
+
+import android.accessibilityservice.AccessibilityService;
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.util.Log;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * ═══════════════════════════════════════════════════════════════════════════════
+ * LauncherStateService — One UI launcher page + drawer detector (opt-in)
+ * ═══════════════════════════════════════════════════════════════════════════════
+ *
+ * Fixes GitHub #10 + #11:
+ *
+ * #10: On One UI, the wallpaper receives NO offset/command/zoom callbacks that
+ *      would tell us the app drawer is open.  This service detects the drawer by
+ *      inspecting the launcher's accessibility node tree, then publishes
+ *      {@link LauncherState#drawerOpen}.  SphereEngine's direct-tap path checks
+ *      this flag so taps on the blurred sphere behind the open drawer no longer
+ *      launch apps.
+ *
+ * #11: One UI never sends page-offset events to live wallpapers.  This service
+ *      reads the launcher's page indicator (content-desc "Page N of M. ") and
+ *      publishes the exact 0-based page into {@link LauncherState#page}.
+ *      SphereEngine uses this as the highest-priority page source, replacing the
+ *      dead-reckoning swipe counter that can drift.
+ *
+ * ─── Scope and privacy ────────────────────────────────────────────────────────
+ *
+ * The service is restricted to {@code packageNames="com.sec.android.app.launcher"}
+ * in launcher_state_service.xml — it NEVER receives events from other apps and
+ * NEVER reads content outside the Samsung launcher.  It reads only the page
+ * indicator's contentDescription (e.g. "Page 1 of 4. "), never any user data.
+ *
+ * ─── Page-indicator format discovered via uiautomator on Galaxy S25 Ultra ────
+ *
+ *   Home-screen page indicator:   contentDescription = "Page 1 of 4. "
+ *   Drawer page indicator:        contentDescription = "Page 1 of 3. "
+ *                                 (also has resource-id containing "applist")
+ *
+ * Surface classification: walk each matching node and its ancestors for a
+ * resource-id containing "applist" or "apps" → drawer; anything else → home.
+ * If the surface cannot be classified, it is treated as home (safe default).
+ *
+ * ─── Threading ────────────────────────────────────────────────────────────────
+ *
+ * This service runs in the same process as MyWallpaperService (single-process
+ * app).  {@link LauncherState} uses volatile fields so reads on the libGDX GL
+ * thread see updates published by this service's main-thread callbacks without
+ * explicit synchronization.
+ *
+ * ─── Battery / performance ───────────────────────────────────────────────────
+ *
+ * - Events are throttled: we skip a scan if less than 80 ms has elapsed since
+ *   the last scan (matches the notificationTimeout in the XML config).
+ * - No heap allocations beyond the unavoidable node-scan loop; the pattern
+ *   and matcher are created once at class-init time.
+ * - Log.d calls are throttled so they do not spam logcat in production.
+ */
+public class LauncherStateService extends AccessibilityService {
+
+    private static final String TAG = "AuraOrbit.A11y";
+
+    /**
+     * Pattern matching One UI page-indicator content descriptions.
+     *
+     * Observed format:  "Page 1 of 4. "  (note trailing ". ")
+     * The pattern is tolerant of any whitespace between words and of the
+     * trailing dot-space, matching both "Page 1 of 4." and "Page 1 of 4. ".
+     */
+    private static final Pattern PAGE_PATTERN =
+            Pattern.compile("(?i)page\\s+(\\d+)\\s+of\\s+(\\d+)");
+
+    /**
+     * Minimum nanoseconds between full node-tree scans.
+     * Rapid scroll events fire many times per second; coalescing to 80 ms
+     * keeps CPU load negligible while still updating at ≥12 Hz.
+     */
+    private static final long SCAN_THROTTLE_NS = 80_000_000L; // 80 ms
+
+    /** Nanosecond timestamp of the previous scan (System.nanoTime()). */
+    private long lastScanNanos = 0L;
+
+    // ─── Log throttle ────────────────────────────────────────────────────────
+    /** Count of events processed since the last log line was emitted. */
+    private int eventCountSinceLog = 0;
+    /** Emit a log line every N events to confirm the service is alive. */
+    private static final int LOG_EVERY_N = 50;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Shared launcher state — visible process-wide via static fields
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Snapshot of the launcher's current paging state.
+     *
+     * All fields are {@code volatile} for safe cross-thread visibility: the
+     * service writes on the main thread; SphereEngine reads on the GL thread.
+     * No locks are needed because each write is to an independent field and
+     * readers can tolerate a frame-level lag in stale values.
+     */
+    public static final class LauncherState {
+        /**
+         * Current 0-based home-screen page (1-based from the indicator minus 1).
+         * Default 0 (first page). Only meaningful when {@link #serviceConnected} is
+         * true AND {@link #updatedNanos} is within the freshness window.
+         */
+        public static volatile int page = 0;
+
+        /**
+         * Total number of home-screen pages reported by the page indicator.
+         * Default 1 (single page assumed when unknown).
+         */
+        public static volatile int pageCount = 1;
+
+        /**
+         * True when the One UI app drawer is open and in the foreground.
+         * SphereEngine suppresses app launches while this is true so that taps
+         * on the blurred sphere behind the drawer do not open apps.
+         */
+        public static volatile boolean drawerOpen = false;
+
+        /**
+         * System.nanoTime() of the most recent update.  SphereEngine treats
+         * values older than 5 seconds as stale and falls through to the next
+         * page-source in the priority chain.
+         */
+        public static volatile long updatedNanos = Long.MIN_VALUE / 2;
+
+        /**
+         * True while the accessibility service is connected and running.
+         * Set to true in {@link LauncherStateService#onServiceConnected()};
+         * set to false in {@link LauncherStateService#onDestroy()} so that
+         * SphereEngine falls back to dead-reckoning the moment the service dies.
+         */
+        public static volatile boolean serviceConnected = false;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  AccessibilityService lifecycle
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Override
+    protected void onServiceConnected() {
+        super.onServiceConnected();
+        LauncherState.serviceConnected = true;
+        // Reset stale state from any previous session.
+        LauncherState.page          = 0;
+        LauncherState.pageCount     = 1;
+        LauncherState.drawerOpen    = false;
+        LauncherState.updatedNanos  = Long.MIN_VALUE / 2;
+        Log.i(TAG, "LauncherStateService connected");
+    }
+
+    @Override
+    public boolean onUnbind(android.content.Intent intent) {
+        LauncherState.serviceConnected = false;
+        Log.i(TAG, "LauncherStateService unbound");
+        return super.onUnbind(intent);
+    }
+
+    @Override
+    public void onDestroy() {
+        LauncherState.serviceConnected = false;
+        Log.i(TAG, "LauncherStateService destroyed");
+        super.onDestroy();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Event handling
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {
+        // ─── 80 ms throttle ──────────────────────────────────────────────────
+        long nowNanos = System.nanoTime();
+        if (nowNanos - lastScanNanos < SCAN_THROTTLE_NS) return;
+        lastScanNanos = nowNanos;
+
+        // ─── Throttled log: confirm service alive without spamming ───────────
+        eventCountSinceLog++;
+        if (eventCountSinceLog >= LOG_EVERY_N) {
+            eventCountSinceLog = 0;
+            Log.d(TAG, "onAccessibilityEvent: service alive, drawerOpen="
+                    + LauncherState.drawerOpen + " page=" + LauncherState.page);
+        }
+
+        // ─── Scan the accessibility node tree ────────────────────────────────
+        AccessibilityNodeInfo root = getRootInActiveWindow();
+        if (root == null) {
+            // Window not yet available (e.g. launcher is animating in).
+            return;
+        }
+
+        try {
+            scanNodeTree(root, event);
+        } finally {
+            // Always recycle the root we obtained — required on all API levels
+            // (on API 33+ recycle() is a no-op, so calling it is always safe).
+            try { root.recycle(); } catch (IllegalStateException ignored) { }
+        }
+    }
+
+    /**
+     * Scans the accessibility node tree to determine:
+     *   1. Which surface is active (home vs. drawer).
+     *   2. The current page and page count from the home-screen indicator.
+     *
+     * Strategy:
+     *   - Walk the tree to find nodes whose contentDescription matches
+     *     {@link #PAGE_PATTERN}.
+     *   - For each matching node, walk its ancestors to classify the surface:
+     *       "applist" or "apps" in any ancestor's resource-id → drawer
+     *       otherwise                                          → home
+     *   - drawerOpen = true when a drawer-classified indicator is present
+     *     and visible, OR when the incoming event's class name hints at the
+     *     apps-view container.
+     *   - page/pageCount come from the home-classified indicator (preferred)
+     *     or the drawer indicator if no home indicator was found.
+     *
+     * @param root  Root node of the active window (caller must recycle).
+     * @param event The triggering event (used for class-name hint).
+     */
+    private void scanNodeTree(AccessibilityNodeInfo root, AccessibilityEvent event) {
+        // Results accumulated during the scan.
+        int  foundHomePage  = -1;   // -1 = not found this scan
+        int  foundHomeCount = -1;
+        boolean foundDrawerIndicator = false;
+
+        // ─── Class-name hint: TYPE_WINDOW_STATE_CHANGED on the apps-view ─────
+        // One UI fires a window-state event whose className contains "AppsView"
+        // or similar when the drawer opens/closes. Use as a fast-path hint.
+        CharSequence eventClass = event.getClassName();
+        boolean classHintDrawer = eventClass != null
+                && (containsIgnoreCase(eventClass, "appsview")
+                    || containsIgnoreCase(eventClass, "applist")
+                    || containsIgnoreCase(eventClass, "allapps"));
+
+        // ─── Recursive node scan ─────────────────────────────────────────────
+        // We process nodes breadth-first by recursing into children. Depth is
+        // bounded by the launcher's UI hierarchy (typically < 20 levels).
+        ScanResult result = new ScanResult();
+        scanNode(root, result);
+
+        foundHomePage        = result.homePage;
+        foundHomeCount       = result.homePageCount;
+        foundDrawerIndicator = result.drawerIndicatorVisible;
+
+        // ─── Publish results ──────────────────────────────────────────────────
+        boolean drawerOpen = foundDrawerIndicator || classHintDrawer;
+
+        int newPage      = (foundHomePage >= 0)  ? foundHomePage      : LauncherState.page;
+        int newPageCount = (foundHomeCount >= 0)  ? foundHomeCount     : LauncherState.pageCount;
+        // If no home indicator was found but a drawer indicator was, keep the
+        // last known home page (drawerOpen is true, sphere is suppressed anyway).
+
+        LauncherState.drawerOpen   = drawerOpen;
+        LauncherState.page         = newPage;
+        LauncherState.pageCount    = newPageCount;
+        LauncherState.updatedNanos = System.nanoTime();
+    }
+
+    /**
+     * Mutable result container used during the node scan to avoid creating
+     * multiple return values.  All fields are plain (no volatile needed —
+     * used only on the service main thread).
+     */
+    private static final class ScanResult {
+        int     homePage             = -1;
+        int     homePageCount        = -1;
+        boolean drawerIndicatorVisible = false;
+    }
+
+    /**
+     * Recursively visits every node in the tree rooted at {@code node},
+     * looking for page-indicator nodes (matched by contentDescription pattern).
+     *
+     * Classification of each matching node:
+     *   - Walk the node and its parents; if ANY has a resource-id substring
+     *     matching "applist" or "apps" → classify as drawer.
+     *   - Otherwise classify as home.
+     *
+     * Nodes that are not visible to the user are skipped (avoids counting
+     * off-screen / detached views).
+     *
+     * @param node    Node to examine (may be null — guard at top of method).
+     * @param result  Accumulator updated in-place.
+     */
+    private void scanNode(AccessibilityNodeInfo node, ScanResult result) {
+        if (node == null) return;
+
+        int childCount = node.getChildCount();
+
+        // ─── Check this node's contentDescription ────────────────────────────
+        CharSequence desc = node.getContentDescription();
+        if (desc != null && desc.length() > 0) {
+            Matcher m = PAGE_PATTERN.matcher(desc);
+            if (m.find()) {
+                // This node is a page indicator. Parse page and count.
+                int indicatorPage  = parseIntSafe(m.group(1), 1);
+                int indicatorCount = parseIntSafe(m.group(2), 1);
+
+                // Classify surface: is this a drawer indicator?
+                boolean isDrawerIndicator = isDrawerNode(node);
+
+                if (isDrawerIndicator) {
+                    // Drawer indicator visible → drawer is open.
+                    if (node.isVisibleToUser()) {
+                        result.drawerIndicatorVisible = true;
+                    }
+                } else {
+                    // Home-screen indicator: update page (only when visible).
+                    if (node.isVisibleToUser() && result.homePage < 0) {
+                        // Convert 1-based indicator to 0-based internal page.
+                        result.homePage      = Math.max(0, indicatorPage - 1);
+                        result.homePageCount = indicatorCount;
+                    }
+                }
+            }
+        }
+
+        // ─── Recurse into children ───────────────────────────────────────────
+        for (int i = 0; i < childCount; i++) {
+            AccessibilityNodeInfo child = null;
+            try {
+                child = node.getChild(i);
+                scanNode(child, result);
+            } finally {
+                // Recycle each child after we finish with it to avoid leaking.
+                if (child != null) {
+                    try { child.recycle(); } catch (IllegalStateException ignored) { }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns true if {@code node} or any of its ancestors has a resource-id
+     * that contains "applist" or "apps" (case-insensitive), indicating that
+     * the node belongs to the app-drawer surface rather than the home workspace.
+     *
+     * One UI observed IDs:
+     *   Drawer page indicator:  "com.sec.android.app.launcher:id/applist_page_indicator"
+     *   Home page indicator:    resource-ids contain "home" or "workspace"
+     *
+     * We walk up to 10 ancestor levels — sufficient for any reasonable launcher
+     * hierarchy and guards against pathological trees that could run for a long time.
+     *
+     * @param node  Starting node (its own resource-id is also checked).
+     * @return true if the node is classified as belonging to the drawer.
+     */
+    private boolean isDrawerNode(AccessibilityNodeInfo node) {
+        AccessibilityNodeInfo current = null;
+        try {
+            // Start check at the node itself (do NOT recycle 'node' — caller owns it).
+            CharSequence ownId = node.getViewIdResourceName();
+            if (ownId != null) {
+                String id = ownId.toString().toLowerCase();
+                if (id.contains("applist") || id.contains("apps")) return true;
+            }
+
+            // Walk ancestors.
+            current = node.getParent();
+            int depth = 0;
+            while (current != null && depth < 10) {
+                CharSequence resId = current.getViewIdResourceName();
+                if (resId != null) {
+                    String id = resId.toString().toLowerCase();
+                    if (id.contains("applist") || id.contains("apps")) {
+                        return true;
+                    }
+                }
+                AccessibilityNodeInfo parent = current.getParent();
+                try { current.recycle(); } catch (IllegalStateException ignored) { }
+                current = parent;
+                depth++;
+            }
+        } finally {
+            // Recycle the last non-null current we have, if any.
+            if (current != null) {
+                try { current.recycle(); } catch (IllegalStateException ignored) { }
+            }
+        }
+        return false;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    //  Utility helpers
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /** Parses an integer string safely, returning {@code fallback} on error. */
+    private static int parseIntSafe(String s, int fallback) {
+        if (s == null) return fallback;
+        try {
+            return Integer.parseInt(s.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /** Case-insensitive substring test on a CharSequence (no allocation). */
+    private static boolean containsIgnoreCase(CharSequence haystack, String needle) {
+        int hLen = haystack.length();
+        int nLen = needle.length();
+        if (nLen == 0) return true;
+        if (hLen < nLen) return false;
+        outer:
+        for (int i = 0; i <= hLen - nLen; i++) {
+            for (int j = 0; j < nLen; j++) {
+                if (Character.toLowerCase(haystack.charAt(i + j))
+                        != Character.toLowerCase(needle.charAt(j))) {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void onInterrupt() {
+        // No active requests to interrupt — this service is passive (observe-only).
+    }
+}

--- a/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
@@ -242,6 +242,13 @@ public class LiveWallpaperSettings extends AppCompatActivity {
         // are serialised and never race each other on disk.
         private ExecutorService executor;
 
+        // ─── Onboarding guard ─────────────────────────────────────────────
+        // True once the permission-onboarding dialog has been shown (or skipped)
+        // during this particular instance of the fragment. Resets on every new
+        // app open (new instance), so users who haven't granted both permissions
+        // are reminded each time they return to the settings screen.
+        private boolean onboardingShownThisInstance = false;
+
         // ─── Photo picker launcher ────────────────────────────────────────
         // MUST be registered as a field initialiser (i.e. before STARTED state)
         // because ActivityResultContracts requires registration before the
@@ -342,6 +349,8 @@ public class LiveWallpaperSettings extends AppCompatActivity {
             requireActivity().setTitle(R.string.settings_title);
             // Refresh all dynamic summaries.
             updateSummaries();
+            // Show the permission onboarding dialog at most once per instance.
+            maybeShowPermissionOnboarding();
         }
 
         @Override
@@ -599,6 +608,78 @@ public class LiveWallpaperSettings extends AppCompatActivity {
                     updateSummaries();
                 });
             });
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        //  Permission onboarding dialog
+        // ─────────────────────────────────────────────────────────────────
+
+        /**
+         * Shows a guided onboarding dialog the first time (per fragment instance)
+         * that one or both special-access grants are missing.
+         *
+         * <p>Android does not allow programmatic granting of Accessibility service
+         * or All-files-access; both require the user to navigate to a system
+         * Settings screen. This dialog deep-links to those screens so the user
+         * doesn't have to hunt for them.</p>
+         *
+         * <p>The dialog is shown AT MOST ONCE per activity instance. Because we do
+         * NOT persist a "never show again" flag, the dialog will re-appear the next
+         * time the user opens the settings activity if a grant is still missing.</p>
+         */
+        private void maybeShowPermissionOnboarding() {
+            // Guard: show at most once per fragment instance.
+            if (onboardingShownThisInstance) return;
+
+            boolean needA11y    = !isA11yServiceEnabled();
+            boolean needStorage = !isExternalStorageManager();
+
+            // Nothing missing — no dialog needed.
+            if (!needA11y && !needStorage) return;
+
+            // Mark as shown for this instance before we build the dialog so that
+            // the flag is set even if the user rotates mid-dialog.
+            onboardingShownThisInstance = true;
+
+            // Build the message body from the missing items.
+            StringBuilder message = new StringBuilder();
+            if (needA11y) {
+                message.append(getString(R.string.onboarding_item_a11y));
+            }
+            if (needA11y && needStorage) {
+                message.append("\n\n");
+            }
+            if (needStorage) {
+                message.append(getString(R.string.onboarding_item_storage));
+            }
+
+            MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.onboarding_title)
+                    .setMessage(message.toString());
+
+            if (needA11y && needStorage) {
+                // Both missing: three buttons — a11y (positive), storage (neutral), Later (negative).
+                builder
+                        .setPositiveButton(R.string.onboarding_btn_enable_page_detection,
+                                (d, w) -> handleExactPageDetectionClick())
+                        .setNeutralButton(R.string.onboarding_btn_wallpaper_access,
+                                (d, w) -> handleSystemWallpaperClick())
+                        .setNegativeButton(R.string.onboarding_btn_later, null);
+            } else if (needA11y) {
+                // Only a11y missing.
+                builder
+                        .setPositiveButton(R.string.onboarding_btn_enable_page_detection,
+                                (d, w) -> handleExactPageDetectionClick())
+                        .setNegativeButton(R.string.onboarding_btn_later, null);
+            } else {
+                // Only storage missing.
+                builder
+                        .setPositiveButton(R.string.onboarding_btn_grant_access,
+                                (d, w) -> handleSystemWallpaperClick())
+                        .setNegativeButton(R.string.onboarding_btn_later, null);
+            }
+
+            builder.show();
         }
 
         // ─────────────────────────────────────────────────────────────────

--- a/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
@@ -1,6 +1,7 @@
 package dev.jaimin.auraorbit;
 
 import android.app.WallpaperManager;
+import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -12,6 +13,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings;
 import android.view.View;
+import android.view.accessibility.AccessibilityManager;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -302,6 +304,18 @@ public class LiveWallpaperSettings extends AppCompatActivity {
                 });
             }
 
+            // ─── pref_exact_page_detection → Accessibility Settings ──────
+            // Sends the user to the system Accessibility Settings screen where
+            // they can enable or disable the LauncherStateService. Title and
+            // summary are refreshed in onResume() to reflect current state.
+            Preference exactPage = findPreference("pref_exact_page_detection");
+            if (exactPage != null) {
+                exactPage.setOnPreferenceClickListener(pref -> {
+                    handleExactPageDetectionClick();
+                    return true;
+                });
+            }
+
         }
 
         @Override
@@ -451,6 +465,61 @@ public class LiveWallpaperSettings extends AppCompatActivity {
             }
         }
 
+        // ─────────────────────────────────────────────────────────────────
+        //  Exact page detection (accessibility service)
+        // ─────────────────────────────────────────────────────────────────
+
+        /**
+         * Returns {@code true} when {@link LauncherStateService} is currently
+         * enabled in the system's Accessibility Settings.
+         *
+         * Implementation: query {@link AccessibilityManager} for the list of
+         * enabled accessibility services and look for our component name.
+         * This works on API 14+ and is the standard approach — it avoids
+         * reading Settings.Secure directly (which requires special permissions
+         * on some API levels).
+         */
+        private boolean isA11yServiceEnabled() {
+            AccessibilityManager am = (AccessibilityManager)
+                    requireContext().getSystemService(android.content.Context.ACCESSIBILITY_SERVICE);
+            if (am == null) return false;
+
+            ComponentName ourComponent = new ComponentName(
+                    requireContext(), LauncherStateService.class);
+
+            java.util.List<AccessibilityServiceInfo> enabled =
+                    am.getEnabledAccessibilityServiceList(
+                            AccessibilityServiceInfo.FEEDBACK_ALL_MASK);
+            if (enabled == null) return false;
+
+            for (AccessibilityServiceInfo info : enabled) {
+                if (ourComponent.flattenToString().equals(
+                        info.getId())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Handles taps on the exact-page-detection preference row.
+         *
+         * Opens the system Accessibility Settings screen. The user enables or
+         * disables the service there; on return to this Activity, onResume()
+         * calls updateSummaries() to reflect the new state.
+         */
+        private void handleExactPageDetectionClick() {
+            try {
+                startActivity(new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS));
+            } catch (ActivityNotFoundException e) {
+                Toast.makeText(
+                        requireContext(),
+                        "Could not open Accessibility Settings — please enable it manually.",
+                        Toast.LENGTH_LONG
+                ).show();
+            }
+        }
+
         /**
          * Launches the system photo picker restricted to images only.
          */
@@ -556,6 +625,20 @@ public class LiveWallpaperSettings extends AppCompatActivity {
                 sysWallpaper.setSummary(granted
                         ? R.string.pref_system_wallpaper_summary_granted
                         : R.string.pref_system_wallpaper_summary_denied);
+            }
+
+            // ─── Exact page detection summary ─────────────────────────────
+            // Refreshed on every resume so the user sees up-to-date state
+            // when returning from the Accessibility Settings screen.
+            Preference exactPage = findPreference("pref_exact_page_detection");
+            if (exactPage != null) {
+                boolean a11yEnabled = isA11yServiceEnabled();
+                exactPage.setTitle(a11yEnabled
+                        ? R.string.pref_exact_page_detection_title_enabled
+                        : R.string.pref_exact_page_detection_title_disabled);
+                exactPage.setSummary(a11yEnabled
+                        ? R.string.pref_exact_page_detection_summary_enabled
+                        : R.string.pref_exact_page_detection_summary_disabled);
             }
 
         }

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
@@ -611,6 +611,9 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
 
     // ─── Interaction tracking ───────────────────────────────────────────
     private boolean userInteracting = false;
+    /** Throttle for the owner-requested live visibility debug dump (1 Hz). */
+    private float visDebugTimer = 0f;
+
     private float idleTimer = 0f;
     private static final float IDLE_DELAY = 3f; // Seconds before auto-spin resumes
 
@@ -2285,6 +2288,13 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
     private void updatePageVisibility(float delta) {
         float targetVisibility;
 
+        // ─── Live-debug state dump (throttled to 1 Hz) ───────────────────────
+        // Owner-requested instrumentation: logs every input to the visibility
+        // decision so on-device fades can be diagnosed from logcat in real time.
+        visDebugTimer += delta;
+        final boolean dbg = visDebugTimer >= 1f;
+        if (dbg) visDebugTimer = 0f;
+
         // ─── Preview hard guard ───────────────────────────────────────────────
         // In the wallpaper-picker preview there are no pages and no offsets.
         // The dead-reckoning branch would immediately compute pageDistance ≥ 1
@@ -2295,6 +2305,7 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
         if (isPreviewMode) {
             targetVisibility = 1f;
             pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
+            if (dbg) logVisDebug("PREVIEW", targetVisibility);
             return;
         }
 
@@ -2329,6 +2340,7 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
                 targetVisibility = MathUtils.clamp(1f - (pageDistance - 0.3f) * 1.5f, 0f, 1f);
                 // Smooth lerp to target
                 pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
+                if (dbg) logVisDebug("A11Y", targetVisibility);
                 return;
             }
             // a11yPage == 0: service is connected and fresh but has never parsed a
@@ -2390,6 +2402,37 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
 
         // Smooth lerp to target
         pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
+
+        if (dbg) {
+            logVisDebug(xOffsetStep > 0f && offsetsLive ? "OFFSETS"
+                    : (!offsetsLive ? "DEAD-RECKONING" : "TRANSIENT"), targetVisibility);
+        }
+    }
+
+    /**
+     * Owner-requested live-debug dump of every input feeding the page-visibility
+     * decision. Called at most once per second from updatePageVisibility (GL thread).
+     * String building only happens when actually logging.
+     */
+    private void logVisDebug(String branch, float target) {
+        Log.d(TAG, "VIS branch=" + branch
+                + " target=" + target
+                + " pv=" + pageVisibility
+                + " | a11y[conn=" + LauncherStateService.LauncherState.serviceConnected
+                + " page=" + LauncherStateService.LauncherState.page
+                + " of=" + LauncherStateService.LauncherState.pageCount
+                + " drawer=" + LauncherStateService.LauncherState.drawerOpen
+                + " ageMs=" + ((System.nanoTime() - LauncherStateService.LauncherState.updatedNanos) / 1_000_000L)
+                + "] | inferredPage=" + inferredPage
+                + " activePage=" + activePage
+                + " offsetsEver=" + offsetEverSeen
+                + " xStep=" + xOffsetStep
+                + " xOff=" + currentXOffset
+                + " | preview=" + isPreviewMode
+                + " visible=" + isVisible
+                + " zoom=" + wallpaperZoom
+                + " returnAnim=" + returnAnim
+                + " launchIdx=" + launchingNodeIdx);
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
@@ -1672,11 +1672,18 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
                 if (!isPreviewMode && launcherSendsCommands) return false;
 
                 // ─── Direct-tap fallback (Samsung One UI or preview) ──────
-                // Drawer guard: One UI zooms the wallpaper when leaving the
-                // plain home view (drawer, recents, edit mode). Suppress
-                // launching while zoomed to avoid firing through overlay UI.
-                // This guard applies only when NOT in preview mode (preview
-                // has no launcher zoom).
+                // Drawer guard #1 (accessibility service): On One UI, taps on
+                // the blurred sphere behind the open app drawer still reach the
+                // wallpaper because One UI never sends android.wallpaper.tap
+                // commands — the zoom-based guard below is the only native
+                // signal, but the service gives a more reliable drawer flag.
+                // Suppress launching when the drawer is freshly detected open.
+                if (!isPreviewMode && isA11yDrawerOpenFresh()) return false;
+
+                // ─── Drawer guard #2 (zoom fallback) ─────────────────────
+                // One UI zooms the wallpaper when leaving the plain home view
+                // (drawer, recents, edit mode). Suppress launching while zoomed
+                // as a fallback when the accessibility service is not enabled.
                 if (!isPreviewMode && wallpaperZoom > 0.4f) return false;
 
                 return raycastAndLaunch(x, y);
@@ -2019,6 +2026,12 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
                 && (System.nanoTime() - lastOffsetTimeNanos) < 10_000_000_000L;
         if (offsetsLive) return;
 
+        // ─── Drawer guard (accessibility service): drawer page swipes must not
+        // advance the home-screen dead-reckoning counter. On One UI, the user
+        // can swipe between pages inside the app drawer — those swipes reach
+        // the wallpaper and would otherwise move inferredPage incorrectly.
+        if (isA11yDrawerOpenFresh()) return;
+
         // Zoom filter: drawer/recents/edit-mode swipes should not change page.
         if (wallpaperZoom >= 0.2f) return;
 
@@ -2281,6 +2294,30 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
         // this guard keeps it locked at 1f every subsequent frame.
         if (isPreviewMode) {
             targetVisibility = 1f;
+            pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
+            return;
+        }
+
+        // ─── Highest-priority source: accessibility service (opt-in, One UI) ──
+        // When LauncherStateService is connected AND its last update is fresh
+        // (within 5 seconds), use the exact page reported by the page indicator
+        // instead of dead-reckoning or offsets.  Falls through when stale or
+        // when the service is not enabled by the user.
+        //
+        // LauncherState.page is 0-based (converted from the 1-based indicator).
+        // activePage is 0-based.  The same falloff formula used by the offset
+        // and dead-reckoning paths keeps behaviour identical.
+        //
+        // Statics are volatile — reads on the GL thread see writes from the
+        // service's main thread without explicit synchronization.
+        final long A11Y_FRESHNESS_NS = 5_000_000_000L; // 5 s
+        boolean a11yFresh = LauncherStateService.LauncherState.serviceConnected
+                && (System.nanoTime() - LauncherStateService.LauncherState.updatedNanos)
+                   < A11Y_FRESHNESS_NS;
+        if (a11yFresh) {
+            float pageDistance = Math.abs(LauncherStateService.LauncherState.page - activePage);
+            targetVisibility = MathUtils.clamp(1f - (pageDistance - 0.3f) * 1.5f, 0f, 1f);
+            // Smooth lerp to target
             pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
             return;
         }
@@ -2848,6 +2885,39 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
     }
 
     // ═══════════════════════════════════════════════════════════════════════
+    //  Accessibility service helpers — LauncherStateService integration
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Returns {@code true} when the accessibility service is connected, its
+     * last update is fresh (within 5 seconds), AND it reports the app drawer
+     * as open.
+     *
+     * <p>Used in three places:
+     * <ol>
+     *   <li>{@link #tap} direct-tap fallback — suppresses launches when the
+     *       drawer is open over the wallpaper (fixes issue #10).</li>
+     *   <li>{@link #onWallpaperTapCommand} — belt-and-suspenders guard for the
+     *       command path (One UI's drawer can be open even when a command fires
+     *       if the zoom signal was missed).</li>
+     *   <li>{@link #commitPageSwipe} — prevents drawer page swipes from
+     *       incrementing the home-screen dead-reckoning counter.</li>
+     * </ol>
+     *
+     * <p>All reads are on the GL thread (GestureDetector callbacks, Gdx.app
+     * postRunnable).  {@link LauncherStateService.LauncherState} fields are
+     * {@code volatile} so no explicit synchronization is needed.
+     *
+     * @return true if a fresh a11y report says the drawer is open.
+     */
+    private boolean isA11yDrawerOpenFresh() {
+        if (!LauncherStateService.LauncherState.serviceConnected) return false;
+        long ageNs = System.nanoTime() - LauncherStateService.LauncherState.updatedNanos;
+        if (ageNs > 5_000_000_000L) return false; // stale → fall through
+        return LauncherStateService.LauncherState.drawerOpen;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
     //  Launch Logic — shared by command path and preview tap path
     // ═══════════════════════════════════════════════════════════════════════
 
@@ -2988,9 +3058,20 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
         launcherSendsCommands = true;
 
         // Marshal from main thread to GL thread for raycast safety.
+        // Also pass a snapshot of the a11y drawer-open flag so the GL thread
+        // can apply the same guard even for command-path launchers (belt-and-
+        // suspenders: on One UI the drawer can be open when this fires).
         final float fx = x;
         final float fy = y;
-        Gdx.app.postRunnable(() -> raycastAndLaunch(fx, fy));
+        Gdx.app.postRunnable(() -> {
+            // Safety guard: if the accessibility service says the drawer is
+            // open (fresh), suppress this tap to avoid launching through overlay.
+            if (isA11yDrawerOpenFresh()) {
+                Log.d(TAG, "onWallpaperTapCommand: suppressed — a11y reports drawer open");
+                return;
+            }
+            raycastAndLaunch(fx, fy);
+        });
     }
 
     /**

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
@@ -2315,11 +2315,24 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
                 && (System.nanoTime() - LauncherStateService.LauncherState.updatedNanos)
                    < A11Y_FRESHNESS_NS;
         if (a11yFresh) {
-            float pageDistance = Math.abs(LauncherStateService.LauncherState.page - activePage);
-            targetVisibility = MathUtils.clamp(1f - (pageDistance - 0.3f) * 1.5f, 0f, 1f);
-            // Smooth lerp to target
-            pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
-            return;
+            int a11yPage = LauncherStateService.LauncherState.page;
+            // One UI home page indicator only exists mid-swipe (the dots fade out at
+            // rest, removing/blanking the node).  Before the first swipe, the service
+            // reports page=0 which means "no data yet", NOT "first page".  Treat
+            // page < 1 as no data and fall through to the next source so the sphere
+            // is visible instead of collapsing immediately after the wallpaper applies.
+            if (a11yPage >= 1) {
+                // Sync dead-reckoning so it takes over seamlessly if the service dies
+                // or data goes stale between swipes.
+                inferredPage = a11yPage - 1; // convert back to 0-based
+                float pageDistance = Math.abs(a11yPage - 1 - activePage);
+                targetVisibility = MathUtils.clamp(1f - (pageDistance - 0.3f) * 1.5f, 0f, 1f);
+                // Smooth lerp to target
+                pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
+                return;
+            }
+            // a11yPage == 0: service is connected and fresh but has never parsed a
+            // page indicator — fall through to offsets / dead-reckoning below.
         }
 
         // ─── Determine whether launcher offsets are currently live ────────────

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,15 @@
     <string name="group_member_count">%1$d apps</string>
     <string name="wallpaper_hint_no_apps">Open AuraOrbit settings\nto pick your apps</string>
 
+    <!-- Permission onboarding dialog -->
+    <string name="onboarding_title">Let AuraOrbit work fully</string>
+    <string name="onboarding_item_a11y">• Exact page detection — reads only your launcher\'s page indicator so the sphere knows which home screen you\'re on.</string>
+    <string name="onboarding_item_storage">• Wallpaper background — your current wallpaper appears behind the sphere (no photo needed).</string>
+    <string name="onboarding_btn_enable_page_detection">Enable page detection</string>
+    <string name="onboarding_btn_wallpaper_access">Wallpaper access</string>
+    <string name="onboarding_btn_grant_access">Grant access</string>
+    <string name="onboarding_btn_later">Later</string>
+
     <!-- Accessibility service description (shown in Settings → Accessibility) -->
     <string name="a11y_service_description">Reads the Samsung launcher\'s page indicator (e.g. "Page 1 of 4") to show the 3D sphere on the correct home page and to detect when the app drawer is open. Only the launcher\'s page indicator is read — no other app content is accessed.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,18 @@
     <string name="member_in_other_group">Already in %1$s</string>
     <string name="group_member_count">%1$d apps</string>
     <string name="wallpaper_hint_no_apps">Open AuraOrbit settings\nto pick your apps</string>
+
+    <!-- Accessibility service description (shown in Settings → Accessibility) -->
+    <string name="a11y_service_description">Reads the Samsung launcher\'s page indicator (e.g. "Page 1 of 4") to show the 3D sphere on the correct home page and to detect when the app drawer is open. Only the launcher\'s page indicator is read — no other app content is accessed.</string>
+
+    <!-- Exact page detection preference category -->
+    <string name="pref_category_sphere_detection">Launcher Integration</string>
+
+    <!-- Exact page detection preference (Sphere category) -->
+    <string name="pref_exact_page_detection_title_disabled">Exact page detection</string>
+    <string name="pref_exact_page_detection_title_enabled">Exact page detection ✓</string>
+    <string name="pref_exact_page_detection_summary_disabled">One UI doesn\'t tell wallpapers which page you\'re on. Enable the AuraOrbit accessibility service so the sphere knows the exact page and the app drawer — it reads only the launcher\'s page indicator.</string>
+    <string name="pref_exact_page_detection_summary_enabled">Reading the launcher page indicator</string>
     <string name="selected_count">%1$d selected</string>
     <string name="picker_select_all">Select all</string>
     <string name="picker_clear_all">Clear all</string>

--- a/app/src/main/res/xml/launcher_state_service.xml
+++ b/app/src/main/res/xml/launcher_state_service.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    AccessibilityService configuration for LauncherStateService.
+
+    Scope: One UI launcher (com.sec.android.app.launcher) only.
+
+    Events:
+      - typeWindowContentChanged: page-indicator text updates as the user swipes.
+      - typeWindowStateChanged:   app drawer open/close transitions.
+      - typeViewScrolled:         in-drawer page swipes.
+
+    canRetrieveWindowContent=true is required to walk the node tree and read
+    the page indicator's contentDescription text.
+
+    notificationTimeout=80 ms: coalesces rapid scroll events so we do not scan
+    the node tree on every single scroll step. Matches the 80 ms throttle used
+    inside LauncherStateService.onAccessibilityEvent.
+-->
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowContentChanged|typeWindowStateChanged|typeViewScrolled"
+    android:packageNames="com.sec.android.app.launcher"
+    android:canRetrieveWindowContent="true"
+    android:notificationTimeout="80"
+    android:description="@string/a11y_service_description" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -50,6 +50,16 @@
             app:min="10" app:showSeekBarValue="true" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/pref_category_sphere_detection">
+        <!-- Exact page detection via accessibility service (opt-in, One UI only).
+             Title and summary are set dynamically in MainSettingsFragment.updateSummaries()
+             to reflect whether the service is currently enabled. -->
+        <Preference
+            android:key="pref_exact_page_detection"
+            android:title="@string/pref_exact_page_detection_title_disabled"
+            android:summary="@string/pref_exact_page_detection_summary_disabled" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/pref_category_performance">
         <ListPreference
             android:key="pref_target_fps"


### PR DESCRIPTION
## Summary

- **Fixes #10**: Taps on the blurred sphere behind the One UI app drawer now correctly no-op. On One UI, wallpapers receive no native drawer-open signal (no offsets, no commands, no zoom during normal drawer use). The new accessibility service detects the drawer state from the launcher's own node tree and publishes it; all three tap-launch paths (direct-tap, command-path, dead-reckoning) check this flag before launching.
- **Fixes #11**: The sphere now knows the exact home-screen page on One UI via the page indicator ("Page N of M. ") read by `LauncherStateService`. This replaces the dead-reckoning swipe counter as the highest-priority page source when the service is enabled.

### Changes

| File | Change |
|---|---|
| `LauncherStateService.java` | NEW — AccessibilityService scoped to `com.sec.android.app.launcher`; reads page indicator, classifies home vs. drawer by ancestor resource-id, publishes to `LauncherState` volatile statics |
| `res/xml/launcher_state_service.xml` | NEW — A11y service config (event types, package scope, canRetrieveWindowContent) |
| `SphereEngine.java` | A11y highest-priority page source in `updatePageVisibility()`; `isA11yDrawerOpenFresh()` helper; drawer guards in `tap()`, `onWallpaperTapCommand`, `commitPageSwipe()` |
| `LiveWallpaperSettings.java` | New "Launcher Integration" pref row; state-dependent title/summary; click → `ACTION_ACCESSIBILITY_SETTINGS` |
| `AndroidManifest.xml` | Service declaration with `BIND_ACCESSIBILITY_SERVICE` permission |
| `strings.xml` / `preferences.xml` | New strings and preference for the settings row |

### Design decisions

- **Graceful fallback**: when service is not enabled or its last update is stale (>5 s), `updatePageVisibility` falls through to offsets-live → dead-reckoning seamlessly. No wedged states.
- **Drawer surface classification**: walk node ancestors for resource-id containing `"applist"` or `"apps"` (drawer) vs. anything else (home). Unknown surface treated as home (safe default).
- **Node recycling**: all `AccessibilityNodeInfo` objects obtained via `getChild()`/`getParent()` are recycled in `finally` blocks. `recycle()` is a no-op on API 33+ but safe to call.
- **Battery**: 80 ms scan throttle + `packageNames` restriction to the One UI launcher ensures the service has negligible impact.
- **Opt-in**: no a11y service is enabled by default; the Settings row explains the scope and links to Accessibility Settings.

## Test plan

- [ ] Build passes: `./gradlew :app:processDebugResources :app:compileDebugJavaWithJavac` — confirmed clean
- [ ] Unit tests pass: `./gradlew :app:testDebugUnitTest` — confirmed green
- [ ] On Galaxy S25 Ultra: enable the service via Settings → Accessibility → AuraOrbit; open the app drawer; tap on the sphere area — no app should launch
- [ ] On Galaxy S25 Ultra: swipe between home pages with service enabled; sphere shows on configured page, hides on others
- [ ] Disable the service; verify sphere falls back to dead-reckoning (no regression on non-One UI devices)
- [ ] Settings row: title shows "✓" when enabled, description shown when disabled; tap → Accessibility Settings

Fixes #10
Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)