### PR TITLE
Sphere Mode: fullscreen sphere with exclusive gestures

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,26 +86,47 @@
         </service>
 
         <!-- ═══════════════════════════════════════════════════════════════
-             2. SETTINGS ACTIVITY
-             
-             Launched from the wallpaper picker's "Settings" button.
-             The user configures:
-               - Which apps to display on the sphere
-               - App grouping (folders with colors)
-               - Whether to retain the system wallpaper as background
-               - Active home screen page for rendering
-             
-             exported=true so the wallpaper picker can launch it via Intent.
+             2. SPHERE MODE ACTIVITY (launcher entry point)
+
+             The app icon opens this fullscreen sphere activity. The sphere
+             renders with the same SphereEngine as the wallpaper, but the
+             activity owns ALL input — no launcher gesture conflict.
+
+             MAIN + LAUNCHER: app icon opens Sphere Mode (not Settings).
+             LiveWallpaperSettings remains accessible via the gear button in
+             Sphere Mode and via the wallpaper picker's Settings link
+             (wallpaper.xml still points to LiveWallpaperSettings).
+             ═══════════════════════════════════════════════════════════════ -->
+        <activity
+            android:name=".SphereModeActivity"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AuraOrbit.SphereMode"
+            android:exported="true"
+            android:screenOrientation="portrait"
+            android:configChanges="orientation|screenSize|keyboardHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- ═══════════════════════════════════════════════════════════════
+             3. SETTINGS ACTIVITY
+
+             Launched from:
+               - The gear button inside SphereModeActivity (explicit Intent).
+               - The wallpaper picker's "Settings" button (via wallpaper.xml
+                 which still points to LiveWallpaperSettings — unchanged).
+
+             The MAIN/LAUNCHER filter has been MOVED to SphereModeActivity.
+             LiveWallpaperSettings remains exported so the wallpaper picker
+             and explicit intents from SphereModeActivity can still reach it.
              ═══════════════════════════════════════════════════════════════ -->
         <activity
             android:name=".LiveWallpaperSettings"
             android:label="@string/settings_title"
             android:theme="@style/Theme.AuraOrbit.Settings"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
         <!-- ═══════════════════════════════════════════════════════════════

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
@@ -178,6 +178,16 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
     // ─── Android Context (passed from MyWallpaperService) ───────────────
     private final Context context;
 
+    /**
+     * When {@code true} this engine is running inside {@link SphereModeActivity}
+     * and owns ALL input exclusively (no launcher gesture conflict, no page
+     * isolation, no command gating).
+     *
+     * <p>Additive flag: every branch that checks this is a new {@code if (activityMode)}
+     * guard that did not exist before — wallpaper-mode behavior is unchanged.
+     */
+    private final boolean activityMode;
+
     // ─── Camera & Rendering ─────────────────────────────────────────────
     private PerspectiveCamera camera;
     private SpriteBatch spriteBatch;       // For 2D background and empty-state hint
@@ -783,7 +793,19 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
      *                extends Context, so the service itself IS a Context.
      */
     public SphereEngine(Context context) {
+        this(context, false);
+    }
+
+    /**
+     * Activity-mode constructor.
+     *
+     * @param context      The Android context ({@link SphereModeActivity}).
+     * @param activityMode {@code true} when running inside a fullscreen activity
+     *                     that owns all input exclusively.
+     */
+    public SphereEngine(Context context, boolean activityMode) {
         this.context = context;
+        this.activityMode = activityMode;
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -1767,6 +1789,13 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
              */
             @Override
             public boolean tap(float x, float y, int count, int button) {
+                // ─── Activity mode: exclusive input — launch directly ─────
+                // Inside our own activity the sphere owns all input. No launcher
+                // gesture conflict, no command gating, no zoom/drawer guards.
+                if (activityMode) {
+                    return raycastAndLaunch(x, y);
+                }
+
                 // ─── Command path: launcher handles launch gating ──────────
                 // If the launcher sends commands, only onWallpaperTapCommand
                 // should launch apps (drawer-safe gating). Stay silent here.
@@ -2095,9 +2124,16 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
                     // One UI emits nothing at all), so the zoom-revert cannot catch
                     // them. Deterministic fix: a one-finger gesture born in these
                     // zones never rotates the sphere and never counts page swipes.
-                    float hFrac = (float) screenY / Math.max(1, Gdx.graphics.getHeight());
-                    edgeClaimedGesture = hFrac < EDGE_EXCLUSION_FRACTION
-                            || hFrac > 1f - EDGE_EXCLUSION_FRACTION;
+                    //
+                    // In activity mode: the activity owns ALL input — no edge
+                    // exclusion zones are needed; every gesture is ours.
+                    if (activityMode) {
+                        edgeClaimedGesture = false;
+                    } else {
+                        float hFrac = (float) screenY / Math.max(1, Gdx.graphics.getHeight());
+                        edgeClaimedGesture = hFrac < EDGE_EXCLUSION_FRACTION
+                                || hFrac > 1f - EDGE_EXCLUSION_FRACTION;
+                    }
 
                     // ── Gesture rotation snapshot for launcher-claim revert ──────
                     // Capture the sphere's current orientation so we can slerp back
@@ -2211,6 +2247,8 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
     private void commitPageSwipe(float velocityX, float velocityY) {
         // Skip inference in preview: sphere always fully visible there.
         if (isPreviewMode) return;
+        // Skip inference in activity mode: no launcher pages exist.
+        if (activityMode) return;
 
         // Skip if two-finger pinch is active (pinch swipes are not page changes).
         if (pinchActive) return;
@@ -2400,7 +2438,9 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
         // (launcher claimed the gesture), AND the gesture is either still in
         // progress OR ended within the CLAIM_WINDOW_NS window (zoom can arrive
         // after finger-lift).
-        if (gestureSnapshotValid && !revertActive && wallpaperZoom > ZOOM_CLAIM_THRESHOLD) {
+        //
+        // In activity mode: no launcher conflict exists — skip revert entirely.
+        if (!activityMode && gestureSnapshotValid && !revertActive && wallpaperZoom > ZOOM_CLAIM_THRESHOLD) {
             boolean gestureInProgress = panInProgress;
             boolean withinWindow = (System.nanoTime() - lastGestureEndNanos) < CLAIM_WINDOW_NS;
             if (gestureInProgress || withinWindow) {
@@ -2544,17 +2584,15 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
         final boolean dbg = visDebugTimer >= 1f;
         if (dbg) visDebugTimer = 0f;
 
-        // ─── Preview hard guard ───────────────────────────────────────────────
-        // In the wallpaper-picker preview there are no pages and no offsets.
-        // The dead-reckoning branch would immediately compute pageDistance ≥ 1
-        // (inferredPage=0, activePage=e.g. 2) and fade the sphere out within ~1 s.
-        // Skip ALL page math in preview: the sphere is always fully visible there.
-        // previewStateChange() already snaps pageVisibility=1 at transition time;
-        // this guard keeps it locked at 1f every subsequent frame.
-        if (isPreviewMode) {
+        // ─── Activity-mode hard guard ─────────────────────────────────────────
+        // In activity mode the sphere is always fully visible — there are no
+        // home-screen pages, no launcher offsets, and no dead-reckoning needed.
+        // Reuse the preview guard pattern (OR-ing activityMode) so the sphere is
+        // pinned to pageVisibility = 1 every frame without any page math.
+        if (isPreviewMode || activityMode) {
             targetVisibility = 1f;
             pageVisibility = MathUtils.lerp(pageVisibility, targetVisibility, delta * 8f);
-            if (dbg) logVisDebug("PREVIEW", targetVisibility);
+            if (dbg) logVisDebug(activityMode ? "ACTIVITY" : "PREVIEW", targetVisibility);
             return;
         }
 

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereModeActivity.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereModeActivity.java
@@ -1,0 +1,165 @@
+package dev.jaimin.auraorbit;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.FrameLayout;
+import android.widget.ImageButton;
+
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
+import com.badlogic.gdx.backends.android.AndroidApplication;
+import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
+
+/**
+ * ═══════════════════════════════════════════════════════════════════════════════
+ * SphereModeActivity — Fullscreen Sphere Mode Entry Point
+ * ═══════════════════════════════════════════════════════════════════════════════
+ *
+ * A fullscreen {@link AndroidApplication} that renders the same 3D sphere as the
+ * live wallpaper, but with the key advantage that the activity owns ALL input.
+ * There is no launcher fighting for one-finger swipes; every gesture goes directly
+ * to the sphere.
+ *
+ * ─── Key differences from wallpaper mode ────────────────────────────────────
+ *
+ * - activityMode=true in SphereEngine: page-visibility is always 1, tap-to-launch
+ *   is always direct (no command gating, no zoom/drawer guards, no edge exclusion).
+ * - Back gesture / button finishes the activity naturally (AndroidApplication
+ *   default behavior — no override needed).
+ * - A floating gear button (top-right) opens LiveWallpaperSettings.
+ * - Launched apps: the sphere fires startActivity, the launched app comes to the
+ *   foreground. This activity remains in the back stack behind it; the user presses
+ *   Back to return to Sphere Mode or Home to leave both. This is the simplest UX
+ *   and requires no callback coordination.
+ *
+ * ─── Immersive fullscreen ─────────────────────────────────────────────────────
+ *
+ * libGDX 1.13.0's AndroidApplicationConfiguration does not expose useImmersiveMode
+ * as a public field (it was removed in earlier 1.1x releases). We use
+ * WindowInsetsControllerCompat directly (targetSdk 35 pattern):
+ *   - BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE: swipe in from edge to temporarily
+ *     reveal status/nav bars (they auto-hide after a moment).
+ *   - hide(statusBars | navigationBars) immediately after the window is decorated.
+ *
+ * Edge-to-edge is enabled via WindowCompat.setDecorFitsSystemWindows(window, false)
+ * so the libGDX surface fills the entire display including cutout areas.
+ */
+public class SphereModeActivity extends AndroidApplication {
+
+    private static final String TAG = "AuraOrbit.SphereMode";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // ─── Fullscreen / edge-to-edge ──────────────────────────────────
+        // Tell the decor not to fit system windows so the GL surface reaches
+        // every pixel including display cutouts.
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+
+        // Keep screen on while Sphere Mode is open.
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+        // ─── libGDX initialization ────────────────────────────────────────
+        // Mirror MyWallpaperService's config: no sensors, depth 16, rgba8888,
+        // no MSAA — identical rendering pipeline, just inside an activity.
+        AndroidApplicationConfiguration config = new AndroidApplicationConfiguration();
+        config.useAccelerometer = false;
+        config.useCompass = false;
+        config.useGyroscope = false;
+        config.depth = 16;
+        config.stencil = 0;
+        config.numSamples = 0;
+        config.r = 8;
+        config.g = 8;
+        config.b = 8;
+        config.a = 8;
+
+        // Initialize libGDX with activityMode=true so the engine bypasses all
+        // wallpaper-specific guards (page isolation, edge exclusion, zoom revert,
+        // command gating). initialize() sets the content view internally.
+        initialize(new SphereEngine(this, true), config);
+
+        // ─── Overlay: floating gear button ─────────────────────────────────
+        // The libGDX surface is now the content view. We overlay an Android
+        // ImageButton on top via addContentView so it receives touch events
+        // without interfering with libGDX's input processing on the GL surface.
+        addSettingsButton();
+
+        // ─── Hide system bars (immersive fullscreen) ─────────────────────
+        // Must be called AFTER super.onCreate / initialize so the window is
+        // fully decorated and the insets controller is available.
+        hideSystemBars();
+    }
+
+    /**
+     * Hides status and navigation bars for a true fullscreen experience.
+     *
+     * Uses WindowInsetsControllerCompat (targetSdk 35 / AndroidX pattern).
+     * BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE lets the user temporarily reveal
+     * the bars by swiping from the edge — they auto-hide after ~2 s.
+     */
+    private void hideSystemBars() {
+        View decorView = getWindow().getDecorView();
+        WindowInsetsControllerCompat controller =
+                WindowCompat.getInsetsController(getWindow(), decorView);
+
+        // Swipe-to-reveal: transient bars appear on edge swipe then auto-hide.
+        controller.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+
+        // Hide both status bar and navigation bar immediately.
+        controller.hide(WindowInsetsCompat.Type.statusBars()
+                | WindowInsetsCompat.Type.navigationBars());
+    }
+
+    /**
+     * Adds a small floating gear (settings) button in the top-right corner.
+     *
+     * The button is overlaid via {@link #addContentView} on top of the libGDX
+     * GL surface using a {@link FrameLayout} wrapper with GRAVITY_TOP|END
+     * placement. Alpha is 0.6f (subtle, non-intrusive).
+     */
+    private void addSettingsButton() {
+        // Convert 40dp to pixels for the button size.
+        int sizePx = (int) (40 * getResources().getDisplayMetrics().density);
+        int marginPx = (int) (12 * getResources().getDisplayMetrics().density);
+
+        ImageButton gearButton = new ImageButton(this);
+        gearButton.setImageResource(android.R.drawable.ic_menu_preferences);
+        gearButton.setBackgroundResource(android.R.drawable.btn_default);
+        gearButton.setAlpha(0.6f);
+        gearButton.setContentDescription(getString(R.string.sphere_mode_open_settings));
+
+        FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(sizePx, sizePx);
+        lp.gravity = Gravity.TOP | Gravity.END;
+        lp.topMargin = marginPx;
+        lp.rightMargin = marginPx;
+
+        gearButton.setOnClickListener(v -> {
+            Intent intent = new Intent(this, LiveWallpaperSettings.class);
+            startActivity(intent);
+        });
+
+        // addContentView places the FrameLayout on top of the existing content
+        // (the libGDX surface) without replacing it.
+        addContentView(gearButton, lp);
+    }
+
+    /**
+     * Re-apply immersive mode when the activity window focus returns
+     * (e.g. after returning from Settings or a launched app).
+     */
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus) {
+            hideSystemBars();
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,9 @@
     <string name="group_member_count">%1$d apps</string>
     <string name="wallpaper_hint_no_apps">Open AuraOrbit settings\nto pick your apps</string>
 
+    <!-- Sphere Mode activity -->
+    <string name="sphere_mode_open_settings">Open settings</string>
+
     <!-- Permission onboarding dialog -->
     <string name="onboarding_title">Let AuraOrbit work fully</string>
     <string name="onboarding_item_a11y">• Exact page detection — reads only your launcher\'s page indicator so the sphere knows which home screen you\'re on.</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -11,4 +11,13 @@
     <style name="Theme.AuraOrbit.Settings" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
+
+    <!-- Sphere Mode theme: NoActionBar, fully transparent/black window background
+         so the libGDX GL surface fills the entire screen without a white flash.
+         Edge-to-edge is configured in SphereModeActivity via WindowCompat. -->
+    <style name="Theme.AuraOrbit.SphereMode" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:windowIsTranslucent">false</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary

- Adds `SphereModeActivity` (extends `AndroidApplication`) that renders the same 3D sphere as the wallpaper but with **exclusive gesture ownership** — no launcher conflict, every touch goes directly to the sphere.
- App icon (MAIN/LAUNCHER) now opens Sphere Mode instead of Settings; Settings remains accessible via the gear button inside Sphere Mode and via the wallpaper picker's Settings link (`wallpaper.xml` unchanged).
- `SphereEngine` gains an `activityMode` flag (additive, all wallpaper-mode behavior unchanged) that bypasses: page visibility math, tap-command gating, edge exclusion zones, zoom-revert, and page-swipe counting.

## What changed

| File | Change |
|------|--------|
| `SphereEngine.java` | New `SphereEngine(Context, boolean activityMode)` constructor; existing one delegates with `false`. Guards added at: `updatePageVisibility`, `tap()`, `touchDown` edge-exclusion, `updatePhysics` revert-arm, `commitPageSwipe`. |
| `SphereModeActivity.java` | New file. `AndroidApplication` with mirrored libGDX config, immersive fullscreen via `WindowInsetsControllerCompat`, floating 40dp gear button (alpha 0.6) launching `LiveWallpaperSettings`. |
| `AndroidManifest.xml` | `SphereModeActivity` declared (exported, portrait, `Theme.AuraOrbit.SphereMode`). MAIN/LAUNCHER moved from `LiveWallpaperSettings` to `SphereModeActivity`. `LiveWallpaperSettings` stays exported. |
| `themes.xml` | `Theme.AuraOrbit.SphereMode` — NoActionBar, black window background, fullscreen. |
| `strings.xml` | `sphere_mode_open_settings` content description. |

## Verification

```
./gradlew :app:processDebugResources :app:compileDebugJavaWithJavac  # clean
./gradlew :app:testDebugUnitTest                                      # green
./gradlew :app:assembleDebug                                          # success
```

Stacked on PR #15 (fix/issue-14-gesture-revert).

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)