### PR TITLE
Fix #25: Background wallpaper UI improvements and features

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    
+    <uses-permission android:name="android.permission.SET_WALLPAPER" />
 
     <!-- ─── Feature Declarations ─────────────────────────────────────────── -->
     <!--

--- a/app/src/main/java/dev/jaimin/auraorbit/BackgroundStore.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/BackgroundStore.java
@@ -2,11 +2,88 @@ package dev.jaimin.auraorbit;
 
 import android.content.Context;
 import android.net.Uri;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 
 public class BackgroundStore {
     public static final String PREF_BACKGROUND_VERSION = "bg_ver";
-    public static boolean exists(Context c) { return false; }
-    public static void clear(Context c) {}
-    public static boolean saveFromUri(Context c, Uri u) { return false; }
-    public static java.io.File file(Context c) { return null; }
+    private static final String DEFAULT_FILE_NAME = "background.png";
+
+    public static boolean exists(Context c) {
+        return file(c).exists();
+    }
+    
+    public static void clear(Context c) {
+        File f = file(c);
+        if (f.exists()) {
+            f.delete();
+        }
+        bumpVersion(c);
+    }
+    
+    public static boolean saveFromUri(Context context, Uri uri) {
+        try {
+            InputStream in = context.getContentResolver().openInputStream(uri);
+            if (in == null) return false;
+            
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = true;
+            BitmapFactory.decodeStream(in, null, options);
+            in.close();
+            
+            int maxSize = 2048;
+            int scale = 1;
+            while ((options.outWidth / scale) > maxSize || (options.outHeight / scale) > maxSize) {
+                scale *= 2;
+            }
+
+            BitmapFactory.Options options2 = new BitmapFactory.Options();
+            options2.inSampleSize = scale;
+            in = context.getContentResolver().openInputStream(uri);
+            Bitmap bitmap = BitmapFactory.decodeStream(in, null, options2);
+            in.close();
+
+            if (bitmap == null) return false;
+
+            // Scale precisely
+            if (bitmap.getWidth() > maxSize || bitmap.getHeight() > maxSize) {
+                float ratio = Math.min((float) maxSize / bitmap.getWidth(), (float) maxSize / bitmap.getHeight());
+                int width = Math.round((float) ratio * bitmap.getWidth());
+                int height = Math.round((float) ratio * bitmap.getHeight());
+                Bitmap scaled = Bitmap.createScaledBitmap(bitmap, width, height, true);
+                if (scaled != bitmap) {
+                    bitmap.recycle();
+                    bitmap = scaled;
+                }
+            }
+
+            File f = file(context);
+            FileOutputStream out = new FileOutputStream(f);
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+            out.flush();
+            out.close();
+            bitmap.recycle();
+            
+            bumpVersion(context);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+    
+    private static void bumpVersion(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        int v = prefs.getInt(PREF_BACKGROUND_VERSION, 0);
+        prefs.edit().putInt(PREF_BACKGROUND_VERSION, v + 1).apply();
+    }
+    
+    public static File file(Context context) {
+        return new File(context.getFilesDir(), DEFAULT_FILE_NAME);
+    }
 }

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereEngine.java
@@ -2460,7 +2460,7 @@ public class SphereEngine implements ApplicationListener, AndroidWallpaperListen
 
         // ─── Layer 1: Background ─────────────────────────────────────────
         // Always draws: user photo if available; gradient texture otherwise.
-        if (!activityMode) {
+        if (!activityMode || backgroundTexture != null) {
             renderBackground();
         }
 

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereModeActivity.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereModeActivity.java
@@ -56,6 +56,12 @@ public class SphereModeActivity extends AndroidApplication {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        android.content.SharedPreferences prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(this);
+        if (prefs.getBoolean("pref_blur_background", false) && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            getWindow().addFlags(android.view.WindowManager.LayoutParams.FLAG_BLUR_BEHIND);
+            getWindow().getAttributes().setBlurBehindRadius(100);
+        }
+
         // ─── Fullscreen / edge-to-edge ──────────────────────────────────
         // Tell the decor not to fit system windows so the GL surface reaches
         // every pixel including display cutouts.
@@ -114,7 +120,6 @@ public class SphereModeActivity extends AndroidApplication {
         hideSystemBars();
 
         // ─── Empty state popup ────────────────────────────────────────────
-        android.content.SharedPreferences prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(this);
         java.util.Set<String> selectedApps = prefs.getStringSet(AppFetcher.PREF_SELECTED_APPS, new java.util.HashSet<>());
         if (selectedApps.isEmpty()) {
             new com.google.android.material.dialog.MaterialAlertDialogBuilder(this)

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/DashboardFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/DashboardFragment.java
@@ -46,6 +46,7 @@ public class DashboardFragment extends Fragment {
     private View customLogoOptionsContainer;
     private com.google.android.material.button.MaterialButton btnWidgetLogo;
     private String selectedColor;
+    private boolean isPickingDeviceWallpaper = false;
 
     private final ActivityResultLauncher<PickVisualMediaRequest> pickMedia =
             registerForActivityResult(
@@ -102,6 +103,15 @@ public class DashboardFragment extends Fragment {
             if (fromUser) prefs.edit().putInt("pref_rotation_speed", (int) value).apply();
         });
 
+        // Blur Background
+        MaterialSwitch switchBlurBackground = view.findViewById(R.id.switch_blur_background);
+        if (switchBlurBackground != null) {
+            switchBlurBackground.setChecked(prefs.getBoolean("pref_blur_background", false));
+            switchBlurBackground.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                prefs.edit().putBoolean("pref_blur_background", isChecked).apply();
+            });
+        }
+
         // FPS
         TextView tvFpsValue = view.findViewById(R.id.tv_fps_value);
         String fpsStr = prefs.getString("pref_target_fps", "120");
@@ -132,11 +142,12 @@ public class DashboardFragment extends Fragment {
         tvBackgroundStatus = view.findViewById(R.id.tv_background_status);
         updateBackgroundStatus();
 
-        view.findViewById(R.id.btn_background).setOnClickListener(v -> {
+        view.findViewById(R.id.btn_app_background).setOnClickListener(v -> {
             if (BackgroundStore.exists(requireContext())) {
                 new MaterialAlertDialogBuilder(requireContext())
                         .setItems(new CharSequence[]{"Choose new photo", "Remove photo", "Cancel"}, (dialog, which) -> {
                             if (which == 0) {
+                                isPickingDeviceWallpaper = false;
                                 launchPicker();
                             } else if (which == 1) {
                                 BackgroundStore.clear(requireContext());
@@ -145,8 +156,14 @@ public class DashboardFragment extends Fragment {
                         })
                         .show();
             } else {
+                isPickingDeviceWallpaper = false;
                 launchPicker();
             }
+        });
+
+        view.findViewById(R.id.btn_set_device_wallpaper).setOnClickListener(v -> {
+            isPickingDeviceWallpaper = true;
+            launchPicker();
         });
 
         // GitHub link
@@ -283,6 +300,20 @@ public class DashboardFragment extends Fragment {
 
     private void saveBackground(@Nullable Uri uri) {
         if (uri == null) return;
+        if (isPickingDeviceWallpaper) {
+            try {
+                android.app.WallpaperManager wm = android.app.WallpaperManager.getInstance(requireContext());
+                java.io.InputStream is = requireContext().getContentResolver().openInputStream(uri);
+                wm.setStream(is);
+                if (is != null) is.close();
+                Toast.makeText(requireContext(), "Device wallpaper updated!", Toast.LENGTH_SHORT).show();
+            } catch (Exception e) {
+                e.printStackTrace();
+                Toast.makeText(requireContext(), "Failed to set wallpaper", Toast.LENGTH_SHORT).show();
+            }
+            return;
+        }
+        
         Context appCtx = requireContext().getApplicationContext();
         Handler mainThread = new Handler(Looper.getMainLooper());
         executor.execute(() -> {

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -22,7 +22,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginTop="24dp" />
-            
+
         <!-- Apps Card -->
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/card_apps"
@@ -132,18 +132,46 @@
                 android:orientation="vertical"
                 android:padding="20dp">
 
-                <!-- Background -->
-                <RelativeLayout
+                <!-- Wallpaper & Background Section Title -->
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Background &amp; Wallpaper"
+                    android:textColor="?attr/colorPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="16dp"/>
+
+                <!-- App Background (Sphere Mode) -->
+                <LinearLayout
+                    android:id="@+id/btn_app_background"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true">
+                    
+                    <ImageView
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:src="@drawable/ic_widget_planet" 
+                        android:padding="8dp"
+                        android:background="@drawable/rounded_bg_solid"
+                        app:tint="?attr/colorPrimary"/>
+                        
                     <LinearLayout
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical">
+                        android:orientation="vertical"
+                        android:layout_marginStart="16dp">
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Background Image"
+                            android:text="Sphere Background"
                             android:textColor="?android:attr/textColorPrimary"
                             android:textSize="16sp"/>
                         <TextView
@@ -151,18 +179,104 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="Default"
-                            android:textColor="?android:attr/textColorSecondary"
-                            android:layout_marginTop="4dp"/>
+                            android:textSize="14sp"
+                            android:textColor="?android:attr/textColorSecondary"/>
                     </LinearLayout>
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btn_background"
-                        style="@style/Widget.Material3.Button.OutlinedButton"
-                        android:layout_width="wrap_content"
+                    
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@android:drawable/ic_menu_edit"
+                        app:tint="?attr/colorOnSurfaceVariant"/>
+                </LinearLayout>
+
+                <!-- Set Device Wallpaper -->
+                <LinearLayout
+                    android:id="@+id/btn_set_device_wallpaper"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginTop="20dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true">
+                    
+                    <ImageView
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:src="@android:drawable/ic_menu_gallery" 
+                        android:padding="8dp"
+                        android:background="@drawable/rounded_bg_solid"
+                        app:tint="?attr/colorPrimary"/>
+                        
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:layout_alignParentEnd="true"
-                        android:layout_centerVertical="true"
-                        android:text="Change" />
-                </RelativeLayout>
+                        android:orientation="vertical"
+                        android:layout_marginStart="16dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Device Wallpaper"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textSize="16sp"/>
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Set home screen wallpaper"
+                            android:textSize="14sp"
+                            android:textColor="?android:attr/textColorSecondary"/>
+                    </LinearLayout>
+                    
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@android:drawable/ic_menu_add"
+                        app:tint="?attr/colorOnSurfaceVariant"/>
+                </LinearLayout>
+
+                <!-- Blur Background Switch -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginTop="20dp">
+                    <ImageView
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:src="@android:drawable/ic_menu_view" 
+                        android:padding="8dp"
+                        android:background="@drawable/rounded_bg_solid"
+                        app:tint="?attr/colorPrimary"/>
+                        
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:layout_marginStart="16dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Blur Home Screen"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textSize="16sp"/>
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="When Sphere is open"
+                            android:textSize="14sp"
+                            android:textColor="?android:attr/textColorSecondary"/>
+                    </LinearLayout>
+                    
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/switch_blur_background"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
 
                 <View
                     android:layout_width="match_parent"


### PR DESCRIPTION
Closes #25. This PR fixes the issue where users couldn't set their wallpaper. It adds a new 'Background & Wallpaper' section in the settings with a modern Material UI, adds the SET_WALLPAPER permission, fully implements the missing BackgroundStore for custom Sphere Backgrounds, and adds a home screen blur feature.