### PR TITLE
feat: automated release CI via git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           KEYSTORE_PATH: ${{ runner.temp }}/keystore.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         run: |
           ./gradlew assembleRelease \
             -PversionName="${{ steps.version.outputs.VERSION }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_OUTPUT
 
       - name: Decode keystore
-        run: printf '%s' "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "$RUNNER_TEMP/keystore.jks"
+        run: printf '%s' "${{ secrets.KEYSTORE_BASE64 }}" | base64 --ignore-garbage -d > "$RUNNER_TEMP/keystore.jks"
 
       - name: Grant execute permission to gradlew
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
+      - name: Get release notes from tag message
+        id: tag_notes
+        run: |
+          NOTES=$(git tag -l --format='%(contents)' "${GITHUB_REF_NAME}")
+          echo "NOTES<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Rename APK to match F-Droid Binaries URL pattern
         run: cp app/build/outputs/apk/release/app-release.apk AuraOrbit-${{ steps.version.outputs.VERSION }}.apk
 
@@ -46,5 +54,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: AuraOrbit-${{ steps.version.outputs.VERSION }}.apk
-          generate_release_notes: true
+          body: ${{ steps.tag_notes.outputs.NOTES }}
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
+      - name: Compute version name and code from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          VERSION_CODE=$((MAJOR * 10000 + MINOR * 100 + PATCH))
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_OUTPUT
+
       - name: Decode keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ github.workspace }}/keystore.jks
 
@@ -33,11 +42,10 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew assembleRelease
-
-      - name: Get version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: |
+          ./gradlew assembleRelease \
+            -PversionName="${{ steps.version.outputs.VERSION }}" \
+            -PversionCode="${{ steps.version.outputs.VERSION_CODE }}"
 
       - name: Get release notes from tag message
         id: tag_notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,19 +26,23 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          if [ "$PATCH" -gt 99 ] || [ "$MINOR" -gt 99 ]; then
+            echo "ERROR: version component exceeds 99 — versionCode will collide" >&2
+            exit 1
+          fi
           VERSION_CODE=$((MAJOR * 10000 + MINOR * 100 + PATCH))
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_OUTPUT
 
       - name: Decode keystore
-        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ github.workspace }}/keystore.jks
+        run: printf '%s' "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "$RUNNER_TEMP/keystore.jks"
 
       - name: Grant execute permission to gradlew
         run: chmod +x gradlew
 
       - name: Build signed release APK
         env:
-          KEYSTORE_PATH: ${{ github.workspace }}/keystore.jks
+          KEYSTORE_PATH: ${{ runner.temp }}/keystore.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
@@ -62,5 +66,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: AuraOrbit-${{ steps.version.outputs.VERSION }}.apk
-          body: ${{ steps.tag_notes.outputs.NOTES }}
+          body: "${{ steps.tag_notes.outputs.NOTES }}"
           fail_on_unmatched_files: true
+
+      - name: Remove keystore
+        if: always()
+        run: rm -f "$RUNNER_TEMP/keystore.jks"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "dev.jaimin.auraorbit"
         minSdk rootProject.ext.androidMinSdk
         targetSdk rootProject.ext.androidTargetSdk
-        versionCode 2
-        versionName "1.0.1"
+        versionCode project.hasProperty('versionCode') ? project.versionCode.toInteger() : 2
+        versionName project.hasProperty('versionName') ? project.versionName : "1.0.1"
     }
 
     signingConfigs {

--- a/app/src/main/java/dev/jaimin/auraorbit/BackgroundStore.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/BackgroundStore.java
@@ -37,10 +37,7 @@ public class BackgroundStore {
             in.close();
             
             int maxSize = 2048;
-            int scale = 1;
-            while ((options.outWidth / scale) > maxSize || (options.outHeight / scale) > maxSize) {
-                scale *= 2;
-            }
+            int scale = computeSampleSize(options.outWidth, options.outHeight, maxSize);
 
             BitmapFactory.Options options2 = new BitmapFactory.Options();
             options2.inSampleSize = scale;
@@ -75,6 +72,14 @@ public class BackgroundStore {
             e.printStackTrace();
             return false;
         }
+    }
+    
+    public static int computeSampleSize(int width, int height, int maxSize) {
+        int scale = 1;
+        while ((width / scale) > maxSize || (height / scale) > maxSize) {
+            scale *= 2;
+        }
+        return scale;
     }
     
     private static void bumpVersion(Context context) {


### PR DESCRIPTION
## Summary
- GitHub Actions workflow that triggers on version tags (`v*.*.*`)
- Automatically computes `versionCode` and `versionName` from the tag — no manual `build.gradle` edits needed
- Builds signed APK using keystore stored in GitHub Secrets
- Creates GitHub Release with `AuraOrbit-{version}.apk` (matches F-Droid `Binaries` URL pattern)
- Release notes come from the annotated git tag message

## Release flow after merging
```bash
git tag -a v2.0.0 -m "What's new:
- Feature A
- Feature B"
git push origin v2.0.0
```
CI does the rest — signs, builds, creates GitHub Release automatically.

## Secrets required (repo Settings → Secrets → Actions)
| Secret | Value |
|---|---|
| `KEYSTORE_BASE64` | `base64 -w 0 /path/to/auraorbit-release.jks` |
| `KEYSTORE_PASSWORD` | Keystore password |
| `KEY_ALIAS` | Key alias (e.g. `auraorbit`) |

## versionCode formula
`major × 10000 + minor × 100 + patch` — e.g. `v2.0.0` → `20000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)