### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "dev.jaimin.auraorbit"
         minSdk rootProject.ext.androidMinSdk
         targetSdk rootProject.ext.androidTargetSdk
-        versionCode 4
-        versionName "2.1.0"
+        versionCode 5
+        versionName "2.2.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
Bumps versionCode to 5 and versionName to 2.2.0. Merging to main will trigger CI to build, sign, tag, and create the GitHub Release automatically.