### PR TITLE
Enable 'Transparent Widget' by default (#47)

### DIFF
--- a/app/src/main/java/dev/jaimin/auraorbit/SphereWidgetProvider.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereWidgetProvider.java
@@ -42,7 +42,7 @@ public class SphereWidgetProvider extends AppWidgetProvider {
                     views.setTextViewText(R.id.widget_label, groupName);
                     views.setTextColor(R.id.widget_label, android.graphics.Color.WHITE);
                     boolean hideLogo = prefs.getBoolean("pref_widget_hide_logo_" + groupName, false);
-                    boolean transparent = prefs.getBoolean("pref_widget_transparent_" + groupName, false);
+                    boolean transparent = prefs.getBoolean("pref_widget_transparent_" + groupName, true);
                     if (transparent || hideLogo) {
                         views.setInt(R.id.widget_icon_container, "setBackgroundColor", android.graphics.Color.TRANSPARENT);
                     } else {
@@ -87,7 +87,7 @@ public class SphereWidgetProvider extends AppWidgetProvider {
                     }
                 } else {
                     String widgetName = prefs.getString("pref_widget_name", "All");
-                    boolean transparent = prefs.getBoolean("pref_widget_transparent", false);
+                    boolean transparent = prefs.getBoolean("pref_widget_transparent", true);
                     boolean hideText = prefs.getBoolean("pref_widget_hide_text", false);
 
                     if (transparent) {
@@ -199,7 +199,7 @@ public class SphereWidgetProvider extends AppWidgetProvider {
                 views.setTextViewText(R.id.widget_label, groupName);
                 views.setTextColor(R.id.widget_label, android.graphics.Color.WHITE);
                 boolean hideLogo = prefs.getBoolean("pref_widget_hide_logo_" + groupName, false);
-                boolean transparent = prefs.getBoolean("pref_widget_transparent_" + groupName, false);
+                boolean transparent = prefs.getBoolean("pref_widget_transparent_" + groupName, true);
                 if (transparent || hideLogo) {
                     views.setInt(R.id.widget_icon_container, "setBackgroundColor", android.graphics.Color.TRANSPARENT);
                 } else {
@@ -252,7 +252,7 @@ public class SphereWidgetProvider extends AppWidgetProvider {
                 }
             } else {
                 String widgetName = prefs.getString("pref_widget_name", "All");
-                boolean transparent = prefs.getBoolean("pref_widget_transparent", false);
+                boolean transparent = prefs.getBoolean("pref_widget_transparent", true);
                 boolean hideText = prefs.getBoolean("pref_widget_hide_text", false);
 
                 if (transparent) {

--- a/app/src/main/java/dev/jaimin/auraorbit/SphereWidgetProvider.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/SphereWidgetProvider.java
@@ -307,12 +307,9 @@ public class SphereWidgetProvider extends AppWidgetProvider {
     }
 
     public static void updateAllWidgets(Context context) {
-        Intent intent = new Intent(context, SphereWidgetProvider.class);
-        intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
         AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
         android.content.ComponentName thisWidget = new android.content.ComponentName(context, SphereWidgetProvider.class);
         int[] appWidgetIds = appWidgetManager.getAppWidgetIds(thisWidget);
-        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, appWidgetIds);
-        context.sendBroadcast(intent);
+        new SphereWidgetProvider().onUpdate(context, appWidgetManager, appWidgetIds);
     }
 }

--- a/app/src/main/java/dev/jaimin/auraorbit/WidgetPinnedReceiver.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/WidgetPinnedReceiver.java
@@ -26,10 +26,7 @@ public class WidgetPinnedReceiver extends BroadcastReceiver {
             AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
             int[] appWidgetIds = new int[]{widgetId};
             
-            Intent updateIntent = new Intent(context, SphereWidgetProvider.class);
-            updateIntent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
-            updateIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, appWidgetIds);
-            context.sendBroadcast(updateIntent);
+            new SphereWidgetProvider().onUpdate(context, appWidgetManager, appWidgetIds);
             
             android.widget.Toast.makeText(context, "Group Saved & Widget Pinned!", android.widget.Toast.LENGTH_SHORT).show();
         }

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/DashboardFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/DashboardFragment.java
@@ -258,7 +258,7 @@ public class DashboardFragment extends Fragment {
         buildColorRow((android.widget.LinearLayout) view.findViewById(R.id.color_row));
 
         MaterialSwitch switchTransparent = view.findViewById(R.id.switch_transparent_widget);
-        switchTransparent.setChecked(prefs.getBoolean("pref_widget_transparent", false));
+        switchTransparent.setChecked(prefs.getBoolean("pref_widget_transparent", true));
         switchTransparent.setOnCheckedChangeListener((buttonView, isChecked) -> {
             prefs.edit().putBoolean("pref_widget_transparent", isChecked).apply();
             SphereWidgetProvider.updateAllWidgets(requireContext());
@@ -501,7 +501,7 @@ public class DashboardFragment extends Fragment {
     private void updateLivePreview() {
         if (!isAdded()) return;
 
-        boolean transparent = prefs.getBoolean("pref_widget_transparent", false);
+        boolean transparent = prefs.getBoolean("pref_widget_transparent", true);
         boolean useThemeColor = prefs.getBoolean("pref_widget_use_theme_color", true);
         boolean hideLogo = prefs.getBoolean("pref_widget_hide_logo", false);
         boolean hideText = prefs.getBoolean("pref_widget_hide_text", false);

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -128,7 +128,7 @@ public class GroupEditFragment extends Fragment {
     private boolean pendingLogoClear = false;
     private boolean isHideLogo = false;
     private boolean isHideText = false;
-    private boolean isTransparent = false;
+    private boolean isTransparent = true;
     private boolean isUseThemeColor = true;
     private int customIconSize = 50;
     private int customSpeed = 100;
@@ -335,7 +335,7 @@ public class GroupEditFragment extends Fragment {
         if (originalGroupName != null) {
             isHideLogo = prefs.getBoolean("pref_widget_hide_logo_" + originalGroupName, false);
             isHideText = prefs.getBoolean("pref_widget_hide_text_" + originalGroupName, false);
-            isTransparent = prefs.getBoolean("pref_widget_transparent_" + originalGroupName, false);
+            isTransparent = prefs.getBoolean("pref_widget_transparent_" + originalGroupName, true);
             isUseThemeColor = prefs.getBoolean("pref_widget_use_theme_color_" + originalGroupName, true);
             customIconSize = prefs.getInt("pref_icon_size_" + originalGroupName, prefs.getInt("pref_icon_size", 50));
             customSpeed = prefs.getInt("pref_rotation_speed_" + originalGroupName, prefs.getInt("pref_rotation_speed", 100));

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -1046,6 +1046,16 @@ public class GroupEditFragment extends Fragment {
             int oldBlurRadius = prefs.getInt("pref_blur_radius_" + originalGroupName, prefs.getInt("pref_blur_radius", 50));
             int oldBlurStrength = prefs.getInt("pref_blur_strength_" + originalGroupName, prefs.getInt("pref_blur_strength", 50));
             
+            // Migrate widget group mappings to new name
+            android.appwidget.AppWidgetManager appWidgetManager = android.appwidget.AppWidgetManager.getInstance(requireContext());
+            android.content.ComponentName thisWidget = new android.content.ComponentName(requireContext(), SphereWidgetProvider.class);
+            int[] appWidgetIds = appWidgetManager.getAppWidgetIds(thisWidget);
+            for (int id : appWidgetIds) {
+                if (originalGroupName.equals(prefs.getString("widget_group_" + id, null))) {
+                    prefs.edit().putString("widget_group_" + id, newName).apply();
+                }
+            }
+            
             prefs.edit()
                 .remove("pref_widget_hide_logo_" + originalGroupName)
                 .remove("pref_widget_hide_text_" + originalGroupName)

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -402,6 +402,13 @@
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginTop="32dp"/>
 
+        <include
+            layout="@layout/layout_widget_preview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_widget_title" />
+
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/card_widget"
             android:layout_width="match_parent"
@@ -410,7 +417,7 @@
             app:cardBackgroundColor="?attr/colorSurfaceVariant"
             app:cardCornerRadius="16dp"
             app:cardElevation="0dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_widget_title">
+            app:layout_constraintTop_toBottomOf="@id/card_preview">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -702,40 +709,7 @@
                         android:layout_height="wrap_content"/>
                 </LinearLayout>
 
-                <!-- Options shown when using CUSTOM LOGO -->
-                <LinearLayout
-                    android:id="@+id/custom_logo_options_container"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:visibility="gone"
-                    android:layout_marginTop="16dp">
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center">
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btn_replace_custom_logo"
-                            style="@style/Widget.Material3.Button.TonalButton"
-                            android:layout_width="0dp"
-                            android:layout_weight="1"
-                            android:layout_height="wrap_content"
-                            android:layout_marginEnd="8dp"
-                            android:text="Replace Logo" />
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btn_remove_custom_logo"
-                            style="@style/Widget.Material3.Button.OutlinedButton"
-                            android:layout_width="0dp"
-                            android:layout_weight="1"
-                            android:layout_height="wrap_content"
-                            android:textColor="#E53935"
-                            app:strokeColor="#E53935"
-                            android:layout_marginStart="8dp"
-                            android:text="Remove Logo" />
-                    </LinearLayout>
-                </LinearLayout>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/fragment_group_edit.xml
+++ b/app/src/main/res/layout/fragment_group_edit.xml
@@ -135,62 +135,12 @@
             app:layout_constraintTop_toBottomOf="@id/card_apps"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/card_preview"
+        <include
+            layout="@layout/layout_widget_preview"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            app:cardBackgroundColor="?attr/colorSurfaceVariant"
-            app:cardCornerRadius="16dp"
-            app:cardElevation="0dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_preview_title">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:gravity="center"
-                android:padding="24dp">
-
-                <FrameLayout
-                    android:id="@+id/preview_icon_container"
-                    android:layout_width="100dp"
-                    android:layout_height="100dp"
-                    android:background="@drawable/rounded_bg_solid">
-                    
-                    <ImageView
-                        android:id="@+id/preview_icon_planet"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:padding="12dp"
-                        android:src="@drawable/ic_widget_planet" />
-
-                    <ImageView
-                        android:id="@+id/preview_icon_ring"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:padding="12dp"
-                        android:src="@drawable/ic_widget_ring" />
-                        
-                    <ImageView
-                        android:id="@+id/preview_custom_logo"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:scaleType="centerCrop"
-                        android:visibility="gone" />
-                </FrameLayout>
-
-                <TextView
-                    android:id="@+id/preview_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Group Name"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
+            app:layout_constraintTop_toBottomOf="@id/tv_preview_title" />
 
         <!-- General Settings Card -->
         <TextView

--- a/app/src/main/res/layout/layout_widget_preview.xml
+++ b/app/src/main/res/layout/layout_widget_preview.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/card_preview"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="16dp"
+    app:cardBackgroundColor="?attr/colorSurfaceVariant"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="0dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="24dp">
+
+        <FrameLayout
+            android:id="@+id/preview_icon_container"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:background="@drawable/rounded_bg_solid">
+            
+            <ImageView
+                android:id="@+id/preview_icon_planet"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="12dp"
+                android:src="@drawable/ic_widget_planet" />
+
+            <ImageView
+                android:id="@+id/preview_icon_ring"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="12dp"
+                android:src="@drawable/ic_widget_ring" />
+                
+            <ImageView
+                android:id="@+id/preview_custom_logo"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="centerCrop"
+                android:visibility="gone" />
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/preview_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Widget Name"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="14sp" />
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
Closes #47. 

When a user uploads a custom logo with a transparent background, the widget's default solid background made it appear as if the image had a black background.

This PR sets the 'Transparent Widget' option to `true` by default for both the ALL widget and group widgets. This provides a better default experience when custom logos are used.