### PR TITLE
Fix: Settings for unassigned widgets now opens Dashboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -93,6 +93,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/LiveWallpaperSettings.java
@@ -85,6 +85,24 @@ public class LiveWallpaperSettings extends AppCompatActivity {
 
         super.onCreate(savedInstanceState);
 
+        // Handle widget configuration intent
+        Intent intent = getIntent();
+        int appWidgetId = intent.getIntExtra(android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_ID, android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID);
+        android.util.Log.d("AuraOrbit", "CONFIGURE check. action=" + intent.getAction() + " appWidgetId=" + appWidgetId);
+        
+        if (appWidgetId != android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID) {
+            Intent resultValue = new Intent();
+            resultValue.putExtra(android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+            setResult(RESULT_OK, resultValue);
+
+            android.content.SharedPreferences prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(this);
+            String groupName = prefs.getString("widget_group_" + appWidgetId, null);
+            android.util.Log.d("AuraOrbit", "CONFIGURE groupName for widget=" + groupName);
+            if (groupName != null) {
+                intent.putExtra("open_group", groupName);
+            }
+        }
+
         // Inflate the activity layout that owns the MaterialToolbar + settings_container.
         // This replaces the implicit android.R.id.content-only approach so that
         // AppBarLayout.fitsSystemWindows handles the status-bar inset and
@@ -123,6 +141,13 @@ public class LiveWallpaperSettings extends AppCompatActivity {
                 getSupportFragmentManager()
                         .beginTransaction()
                         .replace(R.id.settings_container, new dev.jaimin.auraorbit.ui.AppPickerFragment())
+                        .addToBackStack(null)
+                        .commit();
+            } else if (getIntent().hasExtra("open_group")) {
+                String groupName = getIntent().getStringExtra("open_group");
+                getSupportFragmentManager()
+                        .beginTransaction()
+                        .replace(R.id.settings_container, dev.jaimin.auraorbit.ui.GroupEditFragment.newInstance(groupName))
                         .addToBackStack(null)
                         .commit();
             }

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -137,12 +137,7 @@ public class GroupEditFragment extends Fragment {
     private ActivityResultLauncher<PickVisualMediaRequest> pickBackgroundMedia;
     private Uri pendingBackgroundUri = null;
     private boolean pendingBackgroundClear = false;
-    private boolean hasUnsavedChanges = false;
     
-    private void markUnsaved() {
-        hasUnsavedChanges = true;
-    }
-
     // ─── Preview Views ───────────────────────────────────────────────────
     private View previewIconContainer;
     private ImageView previewPlanet;
@@ -199,7 +194,6 @@ public class GroupEditFragment extends Fragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
         executor = Executors.newSingleThreadExecutor();
 
         // Read the argument once; keep in a field for use across methods.
@@ -222,30 +216,6 @@ public class GroupEditFragment extends Fragment {
                 updateBackgroundStatus();
             }
         });
-    }
-
-    @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-        inflater.inflate(R.menu.menu_group_edit, menu);
-        MenuItem saveItem = menu.findItem(R.id.action_save);
-        if (saveItem != null) {
-            View actionView = saveItem.getActionView();
-            if (actionView != null) {
-                actionView.setOnClickListener(v -> onOptionsItemSelected(saveItem));
-            }
-        }
-        super.onCreateOptionsMenu(menu, inflater);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        if (item.getItemId() == R.id.action_save) {
-            TextInputEditText nameInput = requireView().findViewById(R.id.group_name_input);
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-            onSaveClicked(nameInput, prefs);
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
     }
 
     @Nullable
@@ -444,38 +414,12 @@ public class GroupEditFragment extends Fragment {
             @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
             @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
             @Override public void afterTextChanged(Editable s) {
-                markUnsaved();
                 updateLivePreview();
             }
         });
 
         // ─── Color circles ────────────────────────────────────────────────
         buildColorRow(colorRow);
-
-        // ─── Back press callback ──────────────────────────────────────────
-        requireActivity().getOnBackPressedDispatcher().addCallback(getViewLifecycleOwner(), new OnBackPressedCallback(true) {
-            @Override
-            public void handleOnBackPressed() {
-                if (hasUnsavedChanges) {
-                    new MaterialAlertDialogBuilder(requireContext())
-                        .setTitle("Unsaved Changes")
-                        .setMessage("Changes will be discarded. Do you want to discard or save them?")
-                        .setPositiveButton("Save", (dialog, which) -> {
-                            TextInputEditText nameInput = requireView().findViewById(R.id.group_name_input);
-                            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-                            onSaveClicked(nameInput, prefs);
-                        })
-                        .setNegativeButton("Discard/Cancel", (dialog, which) -> {
-                            setEnabled(false);
-                            requireActivity().getOnBackPressedDispatcher().onBackPressed();
-                        })
-                        .show();
-                } else {
-                    setEnabled(false);
-                    requireActivity().getOnBackPressedDispatcher().onBackPressed();
-                }
-            }
-        });
 
         // ─── Pin Widget button ────────────────────────────────────────────
         AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(requireContext());
@@ -986,27 +930,27 @@ public class GroupEditFragment extends Fragment {
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    //  Save handler
+    //  Auto Save handler
     // ─────────────────────────────────────────────────────────────────────
 
-    /**
-     * Validates the input and calls {@link GroupStore#upsert}. On success,
-     * saves to SharedPreferences, shows a toast, and pops the fragment.
-     * On validation failure, shows a descriptive toast and stays open.
-     *
-     * @param nameInput  The name text input view.
-     * @param prefs      SharedPreferences instance.
-     */
-    private void onSaveClicked(@NonNull TextInputEditText nameInput,
-                               @NonNull SharedPreferences prefs) {
+    @Override
+    public void onPause() {
+        super.onPause();
+        saveData();
+    }
+
+    private void saveData() {
+        View root = getView();
+        if (root == null) return;
+        TextInputEditText nameInput = root.findViewById(R.id.group_name_input);
+        if (nameInput == null) return;
+        
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Editable editable = nameInput.getText();
         String newName = (editable == null) ? "" : editable.toString().trim();
 
-        // Validate: name must not be empty.
+        // Validate: name must not be empty. If empty, don't save.
         if (newName.isEmpty()) {
-            Toast.makeText(requireContext(),
-                    R.string.toast_group_name_empty,
-                    Toast.LENGTH_SHORT).show();
             return;
         }
 
@@ -1142,15 +1086,13 @@ public class GroupEditFragment extends Fragment {
             // We do not show the "Saved" Toast here so it doesn't conflict with the system popup
             requestPinWidget(newName);
         } else {
-            Toast.makeText(requireContext(),
-                    R.string.toast_saved,
-                    Toast.LENGTH_SHORT).show();
             // Update existing widgets when a group is edited
             SphereWidgetProvider.updateAllWidgets(requireContext());
         }
 
-        // Return to GroupListFragment (or wherever we came from).
-        getParentFragmentManager().popBackStack();
+        // Update originalGroupName so subsequent auto-saves (e.g. after config change)
+        // know the new identity of this group.
+        originalGroupName = newName;
     }
 
 
@@ -1293,7 +1235,6 @@ public class GroupEditFragment extends Fragment {
 
                 // Row click toggles membership in the working set.
                 holder.itemView.setOnClickListener(v -> {
-                    markUnsaved();
                     boolean nowMember = workingMembers.contains(row.packageName);
                     if (nowMember) {
                         workingMembers.remove(row.packageName);

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -227,6 +227,13 @@ public class GroupEditFragment extends Fragment {
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.menu_group_edit, menu);
+        MenuItem saveItem = menu.findItem(R.id.action_save);
+        if (saveItem != null) {
+            View actionView = saveItem.getActionView();
+            if (actionView != null) {
+                actionView.setOnClickListener(v -> onOptionsItemSelected(saveItem));
+            }
+        }
         super.onCreateOptionsMenu(menu, inflater);
     }
 

--- a/app/src/main/res/layout/action_save_button.xml
+++ b/app/src/main/res/layout/action_save_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/btn_action_save"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:text="@string/btn_save"
+    style="@style/Widget.Material3.Button.TonalButton"
+    app:cornerRadius="20dp" />

--- a/app/src/main/res/menu/menu_group_edit.xml
+++ b/app/src/main/res/menu/menu_group_edit.xml
@@ -4,5 +4,6 @@
     <item
         android:id="@+id/action_save"
         android:title="@string/btn_save"
+        app:actionLayout="@layout/action_save_button"
         app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/xml/sphere_widget_info.xml
+++ b/app/src/main/res/xml/sphere_widget_info.xml
@@ -9,4 +9,6 @@
     android:resizeMode="horizontal|vertical"
     android:previewImage="@mipmap/ic_launcher"
     android:previewLayout="@layout/widget_sphere"
+    android:configure="dev.jaimin.auraorbit.LiveWallpaperSettings"
+    android:widgetFeatures="reconfigurable"
     android:widgetCategory="home_screen" />


### PR DESCRIPTION
Removed the fallback to open the groups fragment when a new widget is configured, allowing it to correctly open the DashboardFragment (home page) instead.