### PR TITLE
Fix: Enhance Save Group UX and prevent premature screen pop

### DIFF
--- a/app/src/main/java/dev/jaimin/auraorbit/GroupStore.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/GroupStore.java
@@ -357,9 +357,6 @@ public final class GroupStore {
             Group fresh = new Group(trimmedNew, color);
             if (packages != null) fresh.packages.addAll(packages);
             groups.add(fresh);
-
-            // Enforce single-membership: remove assigned packages from other groups
-            enforceExclusive(groups, fresh);
             return true;
 
         } else {
@@ -376,9 +373,6 @@ public final class GroupStore {
             target.color = color;
             target.packages.clear();
             if (packages != null) target.packages.addAll(packages);
-
-            // Enforce single-membership for the updated set
-            enforceExclusive(groups, target);
             return true;
         }
     }
@@ -397,21 +391,4 @@ public final class GroupStore {
         return true;
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    //  Private helpers
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /**
-     * Removes every package in {@code owner}'s package set from all OTHER groups,
-     * enforcing the single-membership invariant.
-     *
-     * @param groups  Full group list
-     * @param owner   The group that "owns" its package set after an upsert
-     */
-    private static void enforceExclusive(List<Group> groups, Group owner) {
-        for (Group other : groups) {
-            if (other == owner) continue;
-            other.packages.removeAll(owner.packages);
-        }
-    }
 }

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -483,8 +483,9 @@ public class GroupEditFragment extends Fragment {
         if (originalGroupName == null) {
             btnSaveNewGroup.setVisibility(View.VISIBLE);
             btnSaveNewGroup.setOnClickListener(v -> {
-                saveData();
-                requireActivity().getSupportFragmentManager().popBackStack();
+                if (saveData()) {
+                    requireActivity().getSupportFragmentManager().popBackStack();
+                }
             });
         }
 
@@ -952,11 +953,11 @@ public class GroupEditFragment extends Fragment {
         }
     }
 
-    private void saveData() {
+    private boolean saveData() {
         View root = getView();
-        if (root == null) return;
+        if (root == null) return false;
         TextInputEditText nameInput = root.findViewById(R.id.group_name_input);
-        if (nameInput == null) return;
+        if (nameInput == null) return false;
         
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Editable editable = nameInput.getText();
@@ -964,7 +965,8 @@ public class GroupEditFragment extends Fragment {
 
         // Validate: name must not be empty. If empty, don't save.
         if (newName.isEmpty()) {
-            return;
+            nameInput.setError("Group name cannot be empty");
+            return false;
         }
 
         // Reload latest group list to prevent stale-data issues (another agent
@@ -983,10 +985,11 @@ public class GroupEditFragment extends Fragment {
         if (!ok) {
             // upsert returns false on: name collision with different group,
             // or empty name (already guarded above), or old-name-not-found.
+            nameInput.setError(getString(R.string.toast_group_exists));
             Toast.makeText(requireContext(),
                     R.string.toast_group_exists,
                     Toast.LENGTH_SHORT).show();
-            return;
+            return false;
         }
 
         // Persist the mutated list.
@@ -1106,6 +1109,7 @@ public class GroupEditFragment extends Fragment {
         // Update originalGroupName so subsequent auto-saves (e.g. after config change)
         // know the new identity of this group.
         originalGroupName = newName;
+        return true;
     }
 
 

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -1216,35 +1216,25 @@ public class GroupEditFragment extends Fragment {
             // Detach listener before setting state to avoid re-entrant calls.
             holder.check.setOnCheckedChangeListener(null);
 
-            if (lockedByOtherGroup) {
-                // App belongs to a DIFFERENT group: disable the row entirely.
-                // The checkbox must be unchecked so it can never enter workingMembers.
-                holder.check.setChecked(false);
-                holder.check.setEnabled(false);
-                holder.itemView.setEnabled(false);
-                holder.itemView.setAlpha(0.45f);
-                holder.itemView.setOnClickListener(null); // row click does nothing
-            } else {
-                // App is ungrouped or already in THIS group: fully interactive.
-                holder.check.setEnabled(true);
-                holder.itemView.setEnabled(true);
-                holder.itemView.setAlpha(1f);
+            // App is always fully interactive, even if it belongs to another group.
+            holder.check.setEnabled(true);
+            holder.itemView.setEnabled(true);
+            holder.itemView.setAlpha(1f);
 
-                boolean isMember = workingMembers.contains(row.packageName);
-                holder.check.setChecked(isMember);
+            boolean isMember = workingMembers.contains(row.packageName);
+            holder.check.setChecked(isMember);
 
-                // Row click toggles membership in the working set.
-                holder.itemView.setOnClickListener(v -> {
-                    boolean nowMember = workingMembers.contains(row.packageName);
-                    if (nowMember) {
-                        workingMembers.remove(row.packageName);
-                        holder.check.setChecked(false);
-                    } else {
-                        workingMembers.add(row.packageName);
-                        holder.check.setChecked(true);
-                    }
-                });
-            }
+            // Row click toggles membership in the working set.
+            holder.itemView.setOnClickListener(v -> {
+                boolean nowMember = workingMembers.contains(row.packageName);
+                if (nowMember) {
+                    workingMembers.remove(row.packageName);
+                    holder.check.setChecked(false);
+                } else {
+                    workingMembers.add(row.packageName);
+                    holder.check.setChecked(true);
+                }
+            });
         }
 
         @Override

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -484,7 +484,7 @@ public class GroupEditFragment extends Fragment {
             btnSaveNewGroup.setVisibility(View.VISIBLE);
             btnSaveNewGroup.setOnClickListener(v -> {
                 if (saveData()) {
-                    getParentFragmentManager().popBackStack();
+                    btnSaveNewGroup.setVisibility(View.GONE);
                 }
             });
         }
@@ -966,6 +966,14 @@ public class GroupEditFragment extends Fragment {
         // Validate: name must not be empty. If empty, don't save.
         if (newName.isEmpty()) {
             nameInput.setError("Group name cannot be empty");
+            nameInput.requestFocus();
+            androidx.core.widget.NestedScrollView scrollView = root.findViewById(R.id.scroll_view);
+            if (scrollView != null) {
+                View cardGeneral = root.findViewById(R.id.card_general);
+                if (cardGeneral != null) {
+                    scrollView.smoothScrollTo(0, cardGeneral.getTop());
+                }
+            }
             return false;
         }
 
@@ -986,6 +994,14 @@ public class GroupEditFragment extends Fragment {
             // upsert returns false on: name collision with different group,
             // or empty name (already guarded above), or old-name-not-found.
             nameInput.setError(getString(R.string.toast_group_exists));
+            nameInput.requestFocus();
+            androidx.core.widget.NestedScrollView scrollView = root.findViewById(R.id.scroll_view);
+            if (scrollView != null) {
+                View cardGeneral = root.findViewById(R.id.card_general);
+                if (cardGeneral != null) {
+                    scrollView.smoothScrollTo(0, cardGeneral.getTop());
+                }
+            }
             Toast.makeText(requireContext(),
                     R.string.toast_group_exists,
                     Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -484,7 +484,7 @@ public class GroupEditFragment extends Fragment {
             btnSaveNewGroup.setVisibility(View.VISIBLE);
             btnSaveNewGroup.setOnClickListener(v -> {
                 if (saveData()) {
-                    requireActivity().getSupportFragmentManager().popBackStack();
+                    getParentFragmentManager().popBackStack();
                 }
             });
         }
@@ -1099,12 +1099,13 @@ public class GroupEditFragment extends Fragment {
 
         if (originalGroupName == null) {
             // Automatically prompt the user to pin the widget to their home screen for new groups
-            // We do not show the "Saved" Toast here so it doesn't conflict with the system popup
             requestPinWidget(newName);
         } else {
             // Update existing widgets when a group is edited
             SphereWidgetProvider.updateAllWidgets(requireContext());
         }
+
+        Toast.makeText(requireContext(), "Saved!", Toast.LENGTH_SHORT).show();
 
         // Update originalGroupName so subsequent auto-saves (e.g. after config change)
         // know the new identity of this group.

--- a/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
+++ b/app/src/main/java/dev/jaimin/auraorbit/ui/GroupEditFragment.java
@@ -472,8 +472,19 @@ public class GroupEditFragment extends Fragment {
                     .setOnDismissListener(dialog -> {
                         ViewGroup dp = (ViewGroup) cardApps.getParent();
                         if (dp != null) dp.removeView(cardApps);
+                        cardApps.setVisibility(View.GONE);
+                        ((ViewGroup) root.findViewById(R.id.actions_container).getParent()).addView(cardApps, ((ViewGroup) root.findViewById(R.id.actions_container).getParent()).indexOfChild(tvAppsTitle) + 1);
                     })
                     .show();
+            });
+        }
+        
+        MaterialButton btnSaveNewGroup = root.findViewById(R.id.btn_save_new_group);
+        if (originalGroupName == null) {
+            btnSaveNewGroup.setVisibility(View.VISIBLE);
+            btnSaveNewGroup.setOnClickListener(v -> {
+                saveData();
+                requireActivity().getSupportFragmentManager().popBackStack();
             });
         }
 
@@ -936,7 +947,9 @@ public class GroupEditFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
-        saveData();
+        if (originalGroupName != null) {
+            saveData();
+        }
     }
 
     private void saveData() {

--- a/app/src/main/res/layout/fragment_group_edit.xml
+++ b/app/src/main/res/layout/fragment_group_edit.xml
@@ -57,6 +57,15 @@
                 style="@style/Widget.Material3.Button.TextButton"
                 app:icon="@drawable/ic_pin" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_save_new_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Save"
+                android:visibility="gone"
+                style="@style/Widget.Material3.Button"
+                app:icon="@android:drawable/ic_menu_save" />
+
             <ImageButton
                 android:id="@+id/btn_info_pin_widget"
                 android:layout_width="32dp"

--- a/app/src/main/res/layout/fragment_group_edit.xml
+++ b/app/src/main/res/layout/fragment_group_edit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/scroll_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:clipToPadding="false"


### PR DESCRIPTION
Fixes the premature backstack popping on Save for New Groups and scrolls to the Group Name input field when validation fails.
closes #53 